### PR TITLE
delete worker was redirecting to the wrong index page

### DIFF
--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -102,7 +102,7 @@ class WorkersController < ApplicationController
   	
   	worker.destroy
     
-  	redirect_to workers_index_path, alert: "Worker destroyed successfully."
+  	redirect_to session.delete(:return_to)
 
   end
   


### PR DESCRIPTION
a one line change to fix an issue with the redirect after you delete a worker
