### PR TITLE
fixed the issue causing the team to end when a task was completed

### DIFF
--- a/app/assets/javascripts/authoring/taskStatus.js
+++ b/app/assets/javascripts/authoring/taskStatus.js
@@ -146,7 +146,11 @@ var completeTask = function(groupNum){
     //TODO: Iteration Marker - if we iterate and want to put it on the task, do it here
 
     //Update database, must be false b/c we are not using the old ticker
-    updateStatus(false);
+    //updateStatus(false);
+    
+    /*Note from DR: I commented out the updateStatus(false) because it was causing the team to end when you completed a task
+    I think updateStatus needs to be true since the team is still in progress when you complete a task */
+    updateStatus(true);
     drawEvent(eventToComplete);
 
     //Message the PC that the task has been completed

--- a/app/assets/javascripts/authoring/timeline.js
+++ b/app/assets/javascripts/authoring/timeline.js
@@ -430,12 +430,16 @@ function redrawTimeline() {
 
   //Get the latest time and team status, update x position of cursor
   cursor = timeline_svg.select(".cursor");
-  var latest_time;
+  
+  //NOTE from DR: I commented out the block of code below because it was raising an error when the timeline was loaded 
+  //and the same exact code is included in awareness.js
+  
+  /* var latest_time;
   if (in_progress){
       latest_time = (new Date).getTime();
   } else {
       latest_time = loadedStatus.latest_time;
-  }
+  }*/
   
   //Next line is commented out after disabling the ticker
   //cursor_details = positionCursor(flashTeamsJSON, latest_time);


### PR DESCRIPTION
This fix should stop the team from ending whenever you complete a task and then refresh the page. We were incorrectly updating the status in the completeTask function in taskStatus.js (we were passing in false but should have been true since the team is still in progress when you complete a task). 

I also commented out some code in timeline.js that was raising the "in_progress" variable is undefined error. The same code is included in awareness.js and I'm not sure why it was also in timeline.js. I think it had to do with the cursor, which we no longer have. 

How to test: 
1) Create a team with tasks and press start
2) Complete a task 
3) refresh the page
4) make sure team is still in progress

You might want to test completing several tasks and refreshing to make sure it stays in progress. 
