### PR TITLE
Focused text box after sending chat message

### DIFF
--- a/app/assets/javascripts/authoring/sidebar.js
+++ b/app/assets/javascripts/authoring/sidebar.js
@@ -116,11 +116,12 @@ function sendChatMessage() {
   }
   
   myDataRef.push({name: chat_name, role: chat_role, uniq: uniq_u, date: currentdate.toUTCString(), text: text});
-  $('#messageInput').attr("placeholder", "Type your message here...").val('').blur();
+  $('#messageInput').focus().val('');
 }
 
 $('#messageInput').keydown(function(e){
     if (e.keyCode == 13) {
+        e.preventDefault();
         sendChatMessage();
     }
 });


### PR DESCRIPTION
This was mentioned earlier. When you send a chat message now, the text box gets the focus back and its contents are cleared.
