### PR TITLE
At modal save fix

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -39,7 +39,7 @@ var window_visibility_change = null;
 $(document).ready(function(){
     addCursor();
     cursor = timeline_svg.select(".cursor");
-    console.log("THIS FUNCTION HITS");
+    //console.log("THIS FUNCTION HITS");
     renderEverything(true);
 });
 
@@ -111,7 +111,7 @@ function startFlashTeam() {
     $("div#project-status-container").css('display','');
     $("div#chat-box-container").css('display','');
     $("#flashTeamTitle").css('display','none');
-    console.log("here0");
+    //console.log("here0");
     removeColabBtns();
     removeHandoffBtns();
     startTeam(true);
@@ -122,7 +122,7 @@ function startFlashTeam() {
 
 
 function endTeam() {
-    console.log("TEAM ENDED");
+    //console.log("TEAM ENDED");
     $('#confirmAction').modal('hide');
     updateStatus(false);
     stopCursor();
@@ -201,12 +201,12 @@ function renderEverything(firstTime) {
             renderProjectOverview(); //note: not sure if this goes here, depends on who sees the project overview (e.g., user and/or requester)
         }
 
-        console.log("inside render everything"); 
-        console.log("THIS IS THE DATA", data);
+        //console.log("inside render everything"); 
+        //console.log("THIS IS THE DATA", data);
             
         //get user name and user role for the chat
         if(data == null){
-            console.log("RETURNING BEFORE LOAD"); 
+            //console.log("RETURNING BEFORE LOAD"); 
             // will only be run way at the beginning before any members or events are added
             // will only run in requester's page, because on members' pages, members array
             // length will be greater than zero
@@ -243,7 +243,7 @@ function renderEverything(firstTime) {
 
         if(in_progress){
             colorBox();
-            console.log("flash team in progress");
+            //console.log("flash team in progress");
             $("#flashTeamStartBtn").attr("disabled", "disabled");
             $("#flashTeamStartBtn").css('display','none'); //not sure if this is necessary since it's above 
             $("#flashTeamEndBtn").css('display',''); //not sure if this is necessary since it's above 
@@ -256,7 +256,7 @@ function renderEverything(firstTime) {
             renderMembersUser();
             //startTeam(firstTime);
         } else {
-            console.log("flash team not in progress");
+            //console.log("flash team not in progress");
             
             if(flashTeamsJSON["startTime"] == undefined){
 	            //console.log("NO START TIME!");
@@ -387,41 +387,41 @@ var flashTeamUpdated = function(){
     var updated_live_tasks = loadedStatus.live_tasks
 
     if (updated_drawn_blue_tasks.length != drawn_blue_tasks.length) {
-        console.log("drawn_blue_tasks not same length");
+        /*console.log("drawn_blue_tasks not same length");
         console.log(drawn_blue_tasks);
-        console.log(updated_drawn_blue_tasks);
+        console.log(updated_drawn_blue_tasks);*/
         return true;
     }
     if (updated_completed_red_tasks.length != completed_red_tasks.length) {
-        console.log("completed_red_tasks not same length");
+        /*console.log("completed_red_tasks not same length");
         console.log(completed_red_tasks);
         console.log(updated_completed_red_tasks);
         console.log(loadedStatus.live_tasks);
-        console.log(loadedStatus.delayed_tasks);
+        console.log(loadedStatus.delayed_tasks);*/
         return true;
     }
 
     if(updated_drawn_blue_tasks.sort().join(',') !== drawn_blue_tasks.sort().join(',')){
-        console.log("drawn_blue_tasks not same content");
+        /*console.log("drawn_blue_tasks not same content");
         console.log(drawn_blue_tasks);
-        console.log(updated_drawn_blue_tasks);
+        console.log(updated_drawn_blue_tasks);*/
         return true;
     }
 
     if(updated_completed_red_tasks.sort().join(',') !== completed_red_tasks.sort().join(',')){
-        console.log("completed_red_tasks not same content");
+        /*console.log("completed_red_tasks not same content");
         console.log(completed_red_tasks);
-        console.log(updated_completed_red_tasks);
+        console.log(updated_completed_red_tasks);*/
         return true;
     }
 
      if (updated_live_tasks.length != live_tasks.length) {
-        console.log("live_tasks not same length")
+        //console.log("live_tasks not same length")
         return true;
     }
 
     if(updated_live_tasks.sort().join(',') !== live_tasks.sort().join(',')){
-        console.log("live_tasks not same content");
+        //console.log("live_tasks not same content");
         return true;
     }
     return false;
@@ -440,7 +440,7 @@ var poll = function(){
             if(data == null) return;
             loadedStatus = data;
 
-            console.log("inside poll function");
+            //console.log("inside poll function");
             if(flashTeamEndedorStarted()) {
                 //stopPolling();
                 /*if(isUser) {
@@ -453,7 +453,7 @@ var poll = function(){
                 renderEverything(false);
             } else if (flashTeamUpdated()) {
                 //stopPolling();
-                console.log("FLASH TEAM UPDATED..CALLING renderEverything(FALSE)");
+                //console.log("FLASH TEAM UPDATED..CALLING renderEverything(FALSE)");
                 renderEverything(false);
             } else {
                 drawStartedEvents();
@@ -524,8 +524,8 @@ var loadData = function(){
 
 // user must call this startTeam(true, )
 var startTeam = function(firstTime){
-    console.log("STARTING TEAM");
-    console.log("here1");
+    //console.log("STARTING TEAM");
+    //console.log("here1");
     if(!in_progress) {
         //flashTeamsJSON["original_json"] = JSON.parse(JSON.stringify(flashTeamsJSON));
         //flashTeamsJSON["original_status"] = JSON.parse(JSON.stringify(loadedStatus));
@@ -538,7 +538,7 @@ var startTeam = function(firstTime){
         in_progress = true; // TODO: set before this?
         //added next line to disable the ticker
         updateStatus(true);
-        console.log("here2");
+        //console.log("here2");
     }
 
     //Next line is commented out after disabling the ticker
@@ -572,7 +572,7 @@ var startTeam = function(firstTime){
 var googleDriveLink = function(){
     var gFolderLink = document.getElementById("gFolder");
     gFolderLink.onclick=function(){
-        console.log("is clicked");
+        //console.log("is clicked");
         window.open(flashTeamsJSON.folder[1]);
     }
 };
@@ -580,7 +580,7 @@ var googleDriveLink = function(){
 var drawEvents = function(editable){
     for(var i=0;i<flashTeamsJSON.events.length;i++){
         var ev = flashTeamsJSON.events[i];
-        console.log("DRAWING EVENT " + i + ", with editable: " + editable);
+        //console.log("DRAWING EVENT " + i + ", with editable: " + editable);
         drawEvent(ev);
         //drawPopover(ev, editable, false);
     }
@@ -709,14 +709,14 @@ var drawDelayedTasks = function(){
         if (id_remaining != -1) continue;
 
         var red_width = drawRedBox(ev, task_g, true);
-        console.log(" ^^^^^^^^^^^^^^^^^^^^^^ RED_WIDTH: " + red_width);
+        //console.log(" ^^^^^^^^^^^^^^^^^^^^^^ RED_WIDTH: " + red_width);
         var idx = live_tasks.indexOf(groupNum);
         if(idx != -1) {
-            console.log(" %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% found task " + groupNum + " in live_tasks");
+            //console.log(" %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% found task " + groupNum + " in live_tasks");
             live_tasks.splice(idx, 1);
             delayed_tasks.push(groupNum);
         } else {
-            console.log(" %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% not even in live_tasks");
+            //console.log(" %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% not even in live_tasks");
         }
 
         var groupNum = ev.id;
@@ -739,7 +739,7 @@ var drawDelayedTasks = function(){
 
     if (tasks_after != null){
         var actual_offset = computeTotalOffset(allRanges);
-        console.log("DRAWING DELAYED TASKS AFTER UPDATE");
+        //console.log("DRAWING DELAYED TASKS AFTER UPDATE");
         moveTasksRight(tasks_after, actual_offset, true);
     }
 };

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -904,7 +904,7 @@ function drawTimer(eventObj){
             delayed_tasks.push(groupNum);
     
             drawEvent(eventObj);
-            console.log("in drawTimer: ", remaining_time);
+            //console.log("in drawTimer: ", remaining_time);
         }
 
         eventObj["timer"] = remaining_time;

--- a/app/assets/javascripts/authoring/taskStatus.js
+++ b/app/assets/javascripts/authoring/taskStatus.js
@@ -27,12 +27,8 @@
     }
     live_tasks.push(groupNum);
 
-    //START TIMER
-    //START HERE ALEXANDRA
     updateStatus(true);
     drawEvent(eventObj); //Will update color
-
-    console.log("redraw event after start");
 
     //Close the task modal
     $("#task_modal").modal('hide');
@@ -87,7 +83,7 @@ function confirmCompleteTask(groupNum) {
 
     $(".outputForm").change(function() {
         completed = allCompleted(groupNum);
-        console.log(completed);
+        //console.log(completed);
         if (completed){
             $("#confirmButton").prop('disabled', false);
             $("#confirmButton")[0].innerHTML = "Submit!";
@@ -132,7 +128,7 @@ var allCompleted = function(groupNum){
             }
         } 
             if (value){ 
-            console.log(splitOutputs[i]);
+            //console.log(splitOutputs[i]);
             document.getElementById("output" + splitOutputs[i]).style.display = "block";
         }else{ 
             document.getElementById("output" + splitOutputs[i]).style.display = "none";
@@ -271,14 +267,14 @@ var completeTask = function(groupNum){
     var indexOfJSON = getEventJSONIndex(groupNum);
     var eventToComplete = flashTeamsJSON["events"][indexOfJSON];
     saveDocQuestions(groupNum);
-    console.log(eventToComplete["docQs"]);
+    //console.log(eventToComplete["docQs"]);
     
     if(eventToComplete.status == "delayed"){
         
         var idx = delayed_tasks.indexOf(groupNum);
         if (idx != -1) { // delayed task
             delayed_tasks.splice(idx, 1);
-            console.log("removed task from delayed and added to completed_red");
+            //console.log("removed task from delayed and added to completed_red");
             
         }
         completed_red_tasks.push(groupNum);
@@ -299,7 +295,7 @@ var completeTask = function(groupNum){
         delayed_tasks.splice(idx, 1);
         completed_red_tasks.push(groupNum);
         //updateStatus(true);
-        console.log("removed task from delayed and added to completed_red");
+        //console.log("removed task from delayed and added to completed_red");
         sendEmailOnCompletionOfDelayedTask(groupNum);
     } else {
         idx = live_tasks.indexOf(groupNum);

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -1,9 +1,7 @@
 function showTaskOverview(groupNum){
-
 	var task_id = getEventJSONIndex(groupNum);
 	var eventObj = flashTeamsJSON["events"][task_id];
 	var title = eventObj["title"];
-   	
 	
 	//uniq_u is null for author, we use this to decide whether to show the edit link next to project overview
 	var uniq_u=getParameterByName('uniq');
@@ -61,7 +59,6 @@ function showTaskOverview(groupNum){
 }
 
 function editTaskOverview(popover,groupNum){
-
 	var task_id = getEventJSONIndex(groupNum);
 	var eventObj = flashTeamsJSON["events"][task_id];
 	var title = eventObj["title"];
@@ -110,16 +107,13 @@ function editTaskOverview(popover,groupNum){
             document.getElementById("outputQForm").innerHTML = htmlString;
         });
 
-	}
-
-				
+	}	
 }
 
 function getTaskOverviewForm(groupNum){
-
-var task_id = getEventJSONIndex(groupNum);
+    var task_id = getEventJSONIndex(groupNum);
 	var eventObj = flashTeamsJSON["events"][task_id];
-	 var totalMinutes = eventObj["duration"];
+	var totalMinutes = eventObj["duration"];
     var groupNum = eventObj["id"];
     var title = eventObj["title"];
     var startHr = eventObj["startHr"];
@@ -138,12 +132,12 @@ var task_id = getEventJSONIndex(groupNum);
         questions = questions + eventObj["docQs"][i][0] + "\n";
     }
     var outputQuestions = eventObj["outputQs"];
-/*'<form name="taskOverviewForm" id="taskOverviewForm" style="margin-bottom: 5px;">'
-					+'<textarea type="text"" id="descriptionInput" rows="6" placeholder="Task description ...">'+description+'</textarea>'
-					+ '<a onclick="showTaskOverview('+groupNum+')" style="font-weight: normal;">Cancel</a>'
-					+'</form>';*/
+    /*'<form name="taskOverviewForm" id="taskOverviewForm" style="margin-bottom: 5px;">'
+    					+'<textarea type="text"" id="descriptionInput" rows="6" placeholder="Task description ...">'+description+'</textarea>'
+    					+ '<a onclick="showTaskOverview('+groupNum+')" style="font-weight: normal;">Cancel</a>'
+    					+'</form>';*/
 
-var form ='<form name="taskOverviewForm" id="taskOverviewForm" style="margin-bottom: 5px;">'
+    var form ='<form name="taskOverviewForm" id="taskOverviewForm" style="margin-bottom: 5px;">'
         + '<div class="event-table-wrapper">'
         + '<div class="row-fluid">' 
         + '<div class="span6">'
@@ -195,7 +189,7 @@ var form ='<form name="taskOverviewForm" id="taskOverviewForm" style="margin-bot
         
         + '</form>';
 
-        return form;
+    return form;
 
 }
 
@@ -334,16 +328,6 @@ function getTaskOverviewContent(groupNum){
 function saveTaskOverview(groupNum){
 	var task_index = getEventJSONIndex(groupNum); 
 	var ev = flashTeamsJSON["events"][task_index];
-	 
-
-/*var newEvent = {
-        "title":"New Event", "id":event_counter, "x": snapPoint[0], "min_x": snapPoint[0], "y": snapPoint[1], 
-        "startTime": startTimeObj["startTimeinMinutes"], "duration":duration, "members":[], timer:0, task_startBtn_time:-1, task_endBtn_time:-1,
-        "dri":"", "pc":"", "notes":"", "startHr": startTimeObj["startHr"], "status":"not_started",
-        "startMin": startTimeObj["startMin"], "gdrive":[], "completed_x":null, "inputs":"", "outputs":"",
-        "docQs": [["Please explain all other design or execution decisions made, along with the reason they were made",""], 
-        ["Is there anything else you want other team members, the project coordinator, or the client, to know?",""]],
-        "outputQs":{},"row": Math.floor((snapPoint[1]-5)/_foundry.timeline.rowHeight)};*/
 
     //Update title
     if($("#eventName").val() != "")
@@ -436,7 +420,7 @@ function saveTaskOverview(groupNum){
     ev.outputQs = outQs;
 
     drawEvent(ev, 0);
-
     updateStatus();
+
     $('#task_modal').modal('hide'); 
 }

--- a/app/assets/javascripts/authoring/timeline.js
+++ b/app/assets/javascripts/authoring/timeline.js
@@ -277,7 +277,7 @@ window._foundry = {
     updateNumRows: function(numRows) {
       this.numRows = numRows;
       redrawTimeline();
-      console.log(numRows);
+      //console.log(numRows);
     },
   },
 };
@@ -302,13 +302,13 @@ var task_g = timeline_svg.selectAll(".task_g");
 
 //Turn on the overlay so a user cannot continue to draw events when focus is on a popover
 function overlayOn() {
-    console.log("overlay on");
+    //console.log("overlay on");
     //$("#overlay").css("display", "block");
 };
 
 //Remove the overlay so a user can draw events again
 function overlayOff() {
-    console.log("overlay off");
+    //console.log("overlay off");
     $(".task_rectangle").popover("hide");
     //$("#overlay").css("display", "none");
 };


### PR DESCRIPTION
Redid the function saveTaskOverview in task_modal.js to update the json only, and then call drawEvent. In the past it took data from the form and tried to update pixels itself. This should let us avoid always updating this function whenever we do redesigns (in this scenaio, an hour used to be 100 pixels, now it is not and all the tasks rewrote incorrectly whenever you saved the task modal, even without changes.

To test:
-Want to check that anything you do on the task modal saves properly and renders the event properly
-Want to make sure nothing new that you didn't add to the task modal yourself gets used (e.g., don't change duration but it updates anyways)
-Want to make sure when you drag around and otherwise edit the event, the modal updates. I did nothing in the code related to this, but I may have missed bugs that existed before I fixed this - may be easier to find now that this is fixed

Other note: I removed every console log I could find. We can bring back important ones later (polling logs), but as good practice those should not get merged in unless there is a good reason. 
