### PR TITLE
Dr timer fix

### DIFF
--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -932,7 +932,7 @@ function drawTimer(eventObj){
         var minutesLeft = Math.round(totalMinutes%60);
     }
     
-    // this solves the issue that was causing times with minutes < 10 to cut the first zero 
+    // if the minutes are < 10, you need to add a zero before
     if(minutesLeft < 10){
 	    minutesLeft = '0' + minutesLeft;
     }

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -199,12 +199,25 @@ function getTaskOverviewContent(groupNum){
 
     var hrs = Math.floor(ev.duration/60);
     var mins = ev.duration % 60;
+    
+    // if the minutes are < 10, you need to add a zero before
+    if(mins < 10){
+	    mins = '0' + mins;
+    }
+    
+    var evStartHr = ev.startHr; 
+	var evStartMin = ev.startMin.toFixed(0); 
+	
+	// if the minutes are < 10, you need to add a zero before
+	if(evStartMin < 10){
+	    evStartMin = '0' + evStartMin;
+    }
 
     var content = '<div class="row-fluid" >' 
         + '<div class="span6">'
         + '<b>Event Start:  </b>'
-        + ev.startHr + ':'
-        + ev.startMin.toFixed(0) + '<br>'
+        + evStartHr + ':'
+        + evStartMin + '<br>'
         + '</div>'
         + '<div class="span6" style="margin-left:0px">'
         +'<b>Total Runtime:  </b>' 


### PR DESCRIPTION
Solved issue #131 that was causing times with minutes < 10 (such as 1 hour and 5 minutes) to not show the first zero (i.e. it would show up as 1:5 instead of 1:05). When testing, you need to check times in three places: 

1) Make sure the minute value in the task timer always has two digits (especially when the minute value is < 10)
2) In the task modal, make sure that the start time for times with minute values < 10 always shows two digits (i.e. a task that starts at 2 hours should show 2:00)
3) In the task modal, make sure that the time remaining for times with minute values < 10 always shows two digits (i.e. a task with 1 hour 0 minutes remaining should show 1:00)
