### PR TITLE
removed back button from worker view (it should only show in author view...

### DIFF
--- a/app/views/flash_teams/_header.html.erb
+++ b/app/views/flash_teams/_header.html.erb
@@ -4,16 +4,22 @@
     <span class="text">Foundry</span>
   </div>
   
-  
-  <div class="span3 ft-buttons" id="ft-buttons-left" style="position:absolute;left:180px;top:12px;">
-    <input type="button" class="btn btn-default" id="backBtn" value="Back" onclick="window.location='<%=flash_teams_path%>';"/>
-    <input type="button" class="btn btn-default" id="tourBtn" value="Start Foundry Tour"/>
-  </div>
-   
-   <% if in_author_view %>
-     <div class="span2 ft-buttons" id="ft-buttons-right" style="width:auto;position:absolute;right:12px;top:12px;">
-       <input type="button" class="btn btn-success" id="flashTeamStartBtn" value="Start Team"/>
-       <input type="button" class="btn btn-danger" id="flashTeamEndBtn" value="End Team" style="display: none"/>
-     </div> 
+   <!-- if in author view show the back button on left and foundry tour and start/end button on right --> 
+   <% if in_author_view %> 
+	     <div class="span3 ft-buttons" id="ft-buttons-left" style="position:absolute;left:150px;top:12px;">
+	       <input type="button" class="btn btn-default" id="backBtn" value="Back" onclick="window.location='<%=flash_teams_path%>';"/>
+	  	</div>
+	     
+	     <div class="span2 ft-buttons" id="ft-buttons-right" style="width:auto;position:absolute;right:12px;top:12px;">
+	       <input type="button" class="btn btn-default" id="tourBtn" value="Start Foundry Tour"/>
+	       <input type="button" class="btn btn-success" id="flashTeamStartBtn" value="Start Team"/>
+	       <input type="button" class="btn btn-danger" id="flashTeamEndBtn" value="End Team" style="display: none"/>
+	     </div> 
+     
+     <% else %> <! -- else only show the start foundry tour button --> 
+	     <div class="span2 ft-buttons" id="ft-buttons-right" style="width:auto;position:absolute;right:12px;top:12px;">
+	       <input type="button" class="btn btn-default" id="tourBtn" value="Start Foundry Tour"/>
+	     </div> 
+     
    <% end %>
 </header>


### PR DESCRIPTION
In this PR, I did the three things (see before/after screenshots below for reference): 
1) Removed the back button from the worker view (it should only show in author view since the back button takes the author to his/her library), which solves issue #133 
2) Moved the "start foundry tour" button over to the right in both author and worker view because the alignment looks much better
3) Moved the back button in author view slightly over to the left to improve the alignment of the page

When testing, make sure header buttons are correct in the author view and worker view both before and after team has been started. 

Below is what the new header should look like in author view (left) and worker view (right): 
![image](https://cloud.githubusercontent.com/assets/5275384/5323417/b14652d8-7c84-11e4-9ec2-30043721a0ff.png)

For comparison, below is what the older header looked like in author view (left) and worker view (right): 
![image](https://cloud.githubusercontent.com/assets/5275384/5323427/d649ee14-7c84-11e4-8090-61d6bb023f7e.png)
