### PR TITLE
Event Right Resize Fix

### DIFF
--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -294,7 +294,8 @@ function getWidth(ev) {
 
 function durationForWidth(width) {
     var hrs = parseFloat(width)/parseFloat(RECTANGLE_WIDTH);
-    return hrs*60;
+    var mins = hrs*60;
+    return Math.ceil(mins/15) * 15;
 };
 
 function startHrForX(X){

--- a/app/assets/javascripts/authoring/timeline.js
+++ b/app/assets/javascripts/authoring/timeline.js
@@ -56,12 +56,11 @@ var header_svg = d3TimelineElem.append("svg")
     .style({"display": "block",
             "border-bottom": "solid 1px " + STROKE_COLOR});
 
+//Append timeline to DOM
 var timeline_svg = d3TimelineElem.append("svg")
     .attr("class", "timeline-svg chart")
     .attr("width", SVG_WIDTH)
     .attr("height", SVG_HEIGHT)
-
-//console.log("APPENDED TIMELINE TO DOM!");
 
 window._foundry = {
   timeline: {


### PR DESCRIPTION
I calculate the "durationFromWidth" now using Math.ceil to round up to nearest multiple of 15. Hopefully in future if we change widths again this will help us avoid weird rounding issues. 

To test:
Create a new event, drag the right handle before doing anything else. Make sure time and data update appropriately. 
Check same for left bar. This was not broken before but might be now. 
