### PR TITLE
added the user's role to the left sidebar

### DIFF
--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -162,6 +162,7 @@ end
     flash_team_members.each do |member|
     	if(member['uniq'] == uniq)
     		@member_type = member['type']
+    		@member_role = member['role']
     	end
     end
     

--- a/app/views/flash_teams/_left_sidebar.html.erb
+++ b/app/views/flash_teams/_left_sidebar.html.erb
@@ -47,7 +47,8 @@
 
     <% if in_expert_view %>
       <div class="welcome">
-        <h4>Welcome <%= @user_name %>!</h4>
+        <h4><b>Welcome <%= @user_name %>!</b>
+        <br /> Your role: <%= @member_role %></h4>
       </div>
     
       <div id="project-status-container" class="sidebar-item active">


### PR DESCRIPTION
This resolves part of issue #148 

Specifically, I added the user's role under where it says "Welcome [user name]!" in the left side bar. It should look like the image below. When testing, make sure the user's role (in worker and pc view) appears correctly. 

![image](https://cloud.githubusercontent.com/assets/5275384/5446280/86fe3bc2-8471-11e4-838b-d7a5ca65a167.png)
