### PR TITLE
Handoff Error Check & Routing

### DIFF
--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -82,11 +82,9 @@ function eventMousedown(task2idNum) {
         updateStatus();
         var ev1 = flashTeamsJSON["events"][getEventJSONIndex(task1idNum)];
         var ev2 = flashTeamsJSON["events"][getEventJSONIndex(task2idNum)];
-        var task1X = ev1.x;
-        var task1Width = getWidth(ev1);
-        var task2X = ev2.x;
+        var task1End = ev1.startTime + ev1.duration;
         
-        if ((task1X + task1Width) <= task2X) {
+        if (task1End <= ev2.startTime) {
             var color = colorBox.grabColor();
             var handoffData = {"event1":task1idNum, "event2":task2idNum, 
                 "type":"handoff", "description":"", "id":interaction_counter, "color":color};
@@ -260,7 +258,6 @@ function routeHandoffPath(ev1, ev2, x1, x2, y1, y2) {
     pathStr += "L " + (x2+1) + ", " + y2 + "\n";
     //Line from gutter to second event
     pathStr += "L " + (x2+5) + ", " + y2 + "\n";
-
 
     //Arrowhead
     pathStr += "L" + (x2+5) + ", " + (y2+1) + "\n";


### PR DESCRIPTION
Fixes 2 small issues: 
-Handoffs that were drawn b/t events right on top of each other would fire an error (solves #138 )
-Handoffs drawn between two close events had some awkward pixel misalignment (see photo)

Original: 
![screen shot 2014-12-16 at 1 46 58 am](https://cloud.githubusercontent.com/assets/1930207/5451623/cdc423d2-84c6-11e4-8078-feaac5cc9e40.png)

Post-Fix: 
![screen shot 2014-12-16 at 1 46 42 am](https://cloud.githubusercontent.com/assets/1930207/5451621/ca40c418-84c6-11e4-856c-0fb2b09b62bf.png)

To test, simply play around drawing handoffs. Try with different event types and start times. Also make sure to try drawing handoffs between events that were drawn and then dragged. Also try with events that had time edited by the modal form. 
