### PR TITLE
changed the task modal start/complete button colors

### DIFF
--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -21,16 +21,19 @@ function showTaskOverview(groupNum){
         if(eventObj.status == "started" || eventObj.status == "delayed"){
             $("#start-end-task").css('display', '');
             $("#start-end-task").attr('onclick', 'confirmCompleteTask('+groupNum+')');
+            $("#start-end-task").addClass('btn-success');
             $("#start-end-task").html('Complete');
         }  
         else if(eventObj.status == "completed"){
              $("#start-end-task").css('display', '');
               $("#start-end-task").html('Complete');
+              $("#start-end-task").addClass('btn-success');
               $("#start-end-task").prop('disabled', true)
         }
         else{
            $("#start-end-task").css('display', '');
             $("#start-end-task").attr('onclick', 'startTask('+groupNum+')');
+            $("#start-end-task").addClass('btn-primary');
             $("#start-end-task").html('Start'); 
         }
     }


### PR DESCRIPTION
This PR resolves #150. Specifically, I made the following three changes to the start/complete button on the task modal: 

1) The start button is now blue: 
![image](https://cloud.githubusercontent.com/assets/5275384/5459315/df764d1a-850e-11e4-8272-4a9c65a8469e.png)

2) The complete button (once task is started) is green: 
![image](https://cloud.githubusercontent.com/assets/5275384/5459311/d65ac710-850e-11e4-94a8-cc7bcb213197.png)

3) When the task is completed, the button is a faded out green (since it is disabled): 
![image](https://cloud.githubusercontent.com/assets/5275384/5459302/cba4b754-850e-11e4-99ab-d3117349969d.png)

When testing, create a team, start it and make sure the buttons are the right color. Might want to check in both worker and author view to make sure the changes persist but they should :) 
