### PR TITLE
added 'select member role' as the default in the dropdown for the role 

### DIFF
--- a/app/views/flash_teams/_task_acceptance_content.html.erb
+++ b/app/views/flash_teams/_task_acceptance_content.html.erb
@@ -21,10 +21,11 @@
 		<div class="span10">
 		
 			<p>Congratulations!  You have been hired for the 
-			<select name="task_member">
-			<%@task_members.each do |task_member|%>
-				<%=options_for_select([[task_member['role'], task_member['role']]])%>
-			<%end%>
+			<select name="task_member" required="required">
+				<option value="">-- SELECT MEMBER ROLE --</option>
+				<%@task_members.each do |task_member|%>
+					<%=options_for_select([[task_member['role'], task_member['role']]])%>
+				<%end%>
 			</select> 
 			
 			role to work on the
@@ -43,7 +44,7 @@
 			<p><%= label_tag(:inputs, "Input(s):", :style => "display:inline; font-weight: bold;") %>
 			For this task, you will receive the following input(s):
 					<%= text_field_tag(:inputs, @flash_team_event['inputs'], :class => 'span4') %>. You can access the input(s) at the following link (optional):
-					<%= text_field_tag(:input_link, "", :placeholder => "[INSERT LINK TO INPUT]", :class => 'span6') %></p>
+					<%= text_field_tag(:input_link, "", :placeholder => "OPTIONAL: [INSERT LINK TO INPUT]", :class => 'span6') %></p>
 			
 			<p><%= label_tag(:outputs, "Deliverable(s):", :style => "display:inline; font-weight:bold;") %>
 			<%= text_field_tag(:outputs, @flash_team_event['outputs'], :class => 'span4') %></p>

--- a/app/views/flash_teams/_task_available_content.html.erb
+++ b/app/views/flash_teams/_task_available_content.html.erb
@@ -20,10 +20,12 @@
 		
 		<div class="span10">
 			<p>This is an email from the Stanford HCI Group notifying you that a job requiring a 
-			<select name="task_member">
-			<%@task_members.each do |task_member|%>
-			<%=options_for_select([[task_member['role'], task_member['role']]])%>
-			<%end%>
+
+			<select name="task_member" required="required">
+				<option value="">-- SELECT MEMBER ROLE --</option>
+				<%@task_members.each do |task_member|%>
+					<%=options_for_select([[task_member['role'], task_member['role']]])%>
+				<%end%>
 			</select> 
 			
 			for the <%=text_field_tag(:task_name,  @flash_team_event['title'], :class => 'span4') %> task for the <em><%=@flash_team_json['title']%></em> project 
@@ -41,7 +43,7 @@
 			<p><%= label_tag(:inputs, "Input(s):", :style => "display:inline; font-weight: bold;") %>
 			For this task, you will receive the following input(s):
 					<%= text_field_tag(:inputs, @flash_team_event['inputs'], :class => 'span4') %>. You can access the input(s) at the following link (optional):
-					<%= text_field_tag(:input_link, "", :placeholder => "[INSERT LINK TO INPUT]", :class => 'span6') %></p>
+					<%= text_field_tag(:input_link, "", :placeholder => "OPTIONAL: [INSERT LINK TO INPUT]", :class => 'span6') %></p>
 			
 			<p><%= label_tag(:outputs, "Deliverable(s):", :style => "display:inline; font-weight:bold;") %>
 			<%= text_field_tag(:outputs, @flash_team_event['outputs'], :class => 'span4') %></p>

--- a/app/views/flash_teams/_task_rejection_content.html.erb
+++ b/app/views/flash_teams/_task_rejection_content.html.erb
@@ -21,9 +21,10 @@
 		<div class="span10">
 			<p>Thank you for applying for the 
 			
-				<select name="task_member">
-					<%@task_members.each do |task_member|%>
-						<%=options_for_select([[task_member['role'], task_member['role']]])%>
+				<select name="task_member" required="required">
+					<option value="">-- SELECT MEMBER ROLE --</option>
+						<%@task_members.each do |task_member|%>
+							<%=options_for_select([[task_member['role'], task_member['role']]])%>
 						<%end%>
 				</select> 
 			


### PR DESCRIPTION
Two changes to the hiring emails: 

1) #35: The dropdown for selecting the member role in the task available, task acceptance and task rejection emails, now shows "-- SELECT MEMBER ROLE --" as the default [when testing, make sure that you can't send emails if you haven't selected a member]:
![image](https://cloud.githubusercontent.com/assets/5275384/5460498/482b9e06-8518-11e4-9c0b-de3600158f86.png)

2) #141:  I added "OPTIONAL" to the beginning of the placeholder text for the field with the input deliverable in the task available and task acceptance emails:
![image](https://cloud.githubusercontent.com/assets/5275384/5460489/2728c29c-8518-11e4-8ebf-69b8a7446621.png)

When testing, make sure you can still send emails. You should not be able to submit the form without first selecting a member role from the dropdown. 
