### PR TITLE
Dr hiring fixes

### DIFF
--- a/app/assets/stylesheets/hiring-panel.css.scss
+++ b/app/assets/stylesheets/hiring-panel.css.scss
@@ -154,6 +154,16 @@ ul.sidebar-menu li ul.sub li.active a {
     display: block;
 }
 
+ul.sidebar-menu li.active a {
+    color: #68def0;
+    -webkit-transition: all 0.3s ease;
+    -moz-transition: all 0.3s ease;
+    -o-transition: all 0.3s ease;
+    -ms-transition: all 0.3s ease;
+    transition: all 0.3s ease;
+    display: block;
+}
+
 ul.sidebar-menu li{
     /*line-height: 20px !important;*/
     margin-bottom: 5px;

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -708,7 +708,8 @@ end
    
    def panels
    
-   	@show_right_sidebar = false
+   	#@show_right_sidebar = false
+   	@panels_active = "active"
    	
    	session.delete(:return_to)
    	session[:return_to] ||= request.original_url

--- a/app/views/flash_teams/_task_hiring_email.html.erb
+++ b/app/views/flash_teams/_task_hiring_email.html.erb
@@ -62,7 +62,7 @@
               	  <h5 class="project-name">Project: <%=@flash_team_json["title"]%></h5>
               	   <h6 class="task-name">Task: <%=@flash_team_event["title"]%></h6>
               	  	     
-                   <li class="mt">
+                   <li class=<%=@panels_active%>>
                    
                    <%= link_to raw('<i class="fa fa-th"></i><span>Edit Panels</span>'), controller: "flash_teams", action: "panels" %> 			
                           

--- a/app/views/flash_teams/_task_hiring_email.html.erb
+++ b/app/views/flash_teams/_task_hiring_email.html.erb
@@ -91,8 +91,14 @@
                       <ul class="sub">
                           <%i = 0%>
                           <%@flash_team_json['events'].each do |event|%>
-							<li><%=link_to event["title"], :controller => "flash_teams", :action => "hire_form", :event_id => i %></li>
-							<%i+= 1%>
+                          
+                          	<% if i == @id_task %>
+								<li class="active">
+							<% else %>
+								<li>
+							<% end %>
+								<%=link_to event["title"], :controller => "flash_teams", :action => "hire_form", :event_id => i %></li>
+								<%i+= 1%>
 						<% end %>
                       </ul>
                   </li>


### PR DESCRIPTION
All of the links on the left sidebar highlight properly to reflect current page (this PR updates the edit panels link and the tasks under "view other tasks", which previously didn't highlight). Resolves #29 