### PR TITLE
Dr login fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   def valid_user?
+	  	  
+	  session.delete(:return_to)
+	  session[:return_to] ||= request.original_url
 	  
 	  redirect_to(:controller => :users, :action => :login) and return unless session[:member]
 		  

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   def valid_user?
+	  
+	  redirect_to(:controller => :users, :action => :login) and return unless session[:member]
+		  
 	  if session[:member][:mem_type].nil? || session[:member][:mem_type] == "worker"
 		  	valid_user = false	
 	  elsif session[:member][:mem_type] == "author" || "pc" || "client"

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -451,7 +451,7 @@ end
 	   	@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
-	   	@task_avail_active = "active";
+	   	@task_avail_active = "active"
 
 		if valid_user?	
 			@flash_team = FlashTeam.find(params[:id])

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -6,6 +6,7 @@ require 'securerandom'
 
 class FlashTeamsController < ApplicationController
   helper_method :get_tasks
+  before_filter :valid_user?, only: [:panels, :hire_form, :send_task_available, :task_acceptance, :send_task_acceptance, :task_rejection, :send_task_rejection]
 
 	def new
 	# check to see if the user id exists in the database 
@@ -448,14 +449,22 @@ end
    
    
      def hire_form
+	   
+	   #if valid_user?
+	   	
+	   	
 	   	@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
 	   	@task_avail_active = "active"
 
-		if valid_user?	
+		# if !valid_user?	
+# 			redirect_to(:controller => :users, :action => :login) and return unless session[:member]
+# 		end
+		
+		#if valid_user?	
 			@flash_team = FlashTeam.find(params[:id])
-		end
+		#end
 	   	
 	   	#@flash_team = FlashTeam.find(params[:id])
 	   	
@@ -494,6 +503,8 @@ end
 	    end
 	    
 	    @task_avail_email_subject = "From Stanford HCI Group: " + @flash_team_event["title"] + " Task Is Available"
+	    
+	    #end #end if valid_user?
   end
   
   def send_task_available
@@ -548,13 +559,13 @@ end
 	   	@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
-	   	@task_accept_active = "active";
+	   	@task_accept_active = "active"
 	   	
 	   	#@flash_team = FlashTeam.find(params[:id])
 	   	
-	   	if valid_user?	
+	   	#if valid_user?	
 			@flash_team = FlashTeam.find(params[:id])
-		end
+		#end
 		
 		@workers = Worker.all.order(name: :asc)
 		@panels = Worker.distinct.pluck(:panel)
@@ -598,7 +609,7 @@ end
    		@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
-	   	@task_accept_active = "active";
+	   	@task_accept_active = "active"
 	   	
 	   	@flash_team = FlashTeam.find(params[:id])
 	   	    
@@ -643,13 +654,13 @@ end
    		@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
-	   	@task_reject_active = "active";
+	   	@task_reject_active = "active"
 	   	
 	   	#@flash_team = FlashTeam.find(params[:id])
 	   	
-	   	if valid_user?	
+	   	#if valid_user?	
 			@flash_team = FlashTeam.find(params[:id])
-		end
+		#end
 		
 		@workers = Worker.all.order(name: :asc)
 		@panels = Worker.distinct.pluck(:panel)
@@ -679,7 +690,7 @@ end
   		@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
-	   	@task_reject_active = "active";
+	   	@task_reject_active = "active"
 	   	
 	   	@flash_team = FlashTeam.find(params[:id])
 	   	    
@@ -721,9 +732,9 @@ end
    	@id_task = params[:event_id].to_i
    	
    	#@flash_team = FlashTeam.find(params[:id])
-   	if valid_user?	
+   	#if valid_user?	
 		@flash_team = FlashTeam.find(params[:id])
-	end
+	#end
    	    
    	# Extract data from the JSON
     flash_team_status = JSON.parse(@flash_team.status)

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -108,6 +108,9 @@ end
  
   def edit
   
+  	session.delete(:return_to)
+	session[:return_to] ||= request.original_url
+	  
   if !params.has_key?("uniq") #if in author view
 	  	if session[:user].nil? 
 			@user = nil 

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -449,29 +449,19 @@ end
    
    
      def hire_form
-	   
-	   #if valid_user?
-	   	
+	   	   	
 	   	@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	
 	   	@task_avail_active = "active"
 
-		# if !valid_user?	
-# 			redirect_to(:controller => :users, :action => :login) and return unless session[:member]
-# 		end
-		
-		#if valid_user?	
-			@flash_team = FlashTeam.find(params[:id])
-		#end
-	   	
-	   	#@flash_team = FlashTeam.find(params[:id])
-	   	
-	   		@workers = Worker.all.order(name: :asc)
-    	
-	   		@panels = Worker.distinct.pluck(:panel)
-  	
-	   		@fw = Worker.all.pluck(:email)   
+		@flash_team = FlashTeam.find(params[:id])
+   		   	
+   		@workers = Worker.all.order(name: :asc)
+	
+   		@panels = Worker.distinct.pluck(:panel)
+	
+   		@fw = Worker.all.pluck(:email)   
 	   	    
 	   	# Extract data from the JSON
 	    flash_team_status = JSON.parse(@flash_team.status)
@@ -503,7 +493,6 @@ end
 	    
 	    @task_avail_email_subject = "From Stanford HCI Group: " + @flash_team_event["title"] + " Task Is Available"
 	    
-	    #end #end if valid_user?
   end
   
   def send_task_available
@@ -559,12 +548,8 @@ end
 	   	@id_task = params[:event_id].to_i
 	   	
 	   	@task_accept_active = "active"
-	   	
-	   	#@flash_team = FlashTeam.find(params[:id])
-	   	
-	   	#if valid_user?	
-			@flash_team = FlashTeam.find(params[:id])
-		#end
+	   		   	
+		@flash_team = FlashTeam.find(params[:id])
 		
 		@workers = Worker.all.order(name: :asc)
 		@panels = Worker.distinct.pluck(:panel)
@@ -654,12 +639,8 @@ end
 	   	@id_task = params[:event_id].to_i
 	   	
 	   	@task_reject_active = "active"
-	   	
-	   	#@flash_team = FlashTeam.find(params[:id])
-	   	
-	   	#if valid_user?	
-			@flash_team = FlashTeam.find(params[:id])
-		#end
+	   		   	
+		@flash_team = FlashTeam.find(params[:id])
 		
 		@workers = Worker.all.order(name: :asc)
 		@panels = Worker.distinct.pluck(:panel)
@@ -730,10 +711,7 @@ end
    	@id_team = params[:id]
    	@id_task = params[:event_id].to_i
    	
-   	#@flash_team = FlashTeam.find(params[:id])
-   	#if valid_user?	
-		@flash_team = FlashTeam.find(params[:id])
-	#end
+	@flash_team = FlashTeam.find(params[:id])
    	    
    	# Extract data from the JSON
     flash_team_status = JSON.parse(@flash_team.status)

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -113,13 +113,13 @@ end
 			@user = nil 
 			@title = "Invalid User ID"
 			@flash_team = nil
-			redirect_to(welcome_index_path)			
+			redirect_to(welcome_index_path) and return		
 		else 
 			@flash_team = FlashTeam.find(params[:id])
 			
 			if @flash_team.user_id != session[:user].id 
 				flash[:notice] = 'You cannot access this flash team.' 
-				redirect_to(flash_teams_path)
+				redirect_to(flash_teams_path) and return 
 			end
 		end
 			

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -452,7 +452,6 @@ end
 	   
 	   #if valid_user?
 	   	
-	   	
 	   	@id_team = params[:id]
 	   	@id_task = params[:event_id].to_i
 	   	

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,7 +60,12 @@ class UsersController < ApplicationController
 				session[:member] ||= {:mem_uniq => "author", :mem_type => "author"}
 
 				flash[:notice] = "Welcome back, #{session[:user].username}!"
-				redirect_to(:controller => :flash_teams, :action => :index)
+								
+				if !session[:return_to].nil?
+					redirect_to(session[:return_to])
+				else
+					redirect_to(:controller => :flash_teams, :action => :index)
+				end
 							
 		else #login does not exist in the database
 			flash[:notice] = "Invalid username."


### PR DESCRIPTION
This PR resolves the problems faced when trying to access the hiring portal and other pages that was causing a red "status nil" error page to appear. 

To test:

1) Copy the URLs for one of the team workflows (i.e. http://localhost:3000/flash_teams/21/edit) and some of the direct urls to the different hiring pages (i.e. http://localhost:3000/flash_teams/21/0/hire_form) and panel (i.e. http://localhost:3000/flash_teams/21/0/panels) and the other panel (http://localhost:3000/workers/index). 

2) Open an incognito window and try to access those pages -- you should automatically be redirected to the login page. After you login, it should redirect you to the page you were trying to access. Each time you want to test one of the pages, you need to make sure you logout (you can just go to http://localhost:3000/users/logout to make it easier to logout). 

Make sure that you are able to access all of the pages after logging in and that you never encounter one of those ugly red error pages when trying to access a page you don't have access too (it should always redirect you to the login page). Also, make sure that you are correctly redirected to the right page you were trying to access before you were redirected to the login page. 

