### PR TITLE
Dr config vars

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -5,8 +5,8 @@
 
 var poll_interval = 5000; // 20 seconds
 var poll_interval_id;
-var task_timer_interval = 1000; // "normal" speed is 60000. If 1000 : each second is a minute on timeline. 
-var timeline_interval = 10000; // "normal" speed timer is 30 minutes (1800000 milliseconds); fast timer is 10 seconds (10000 milliseconds)
+//var task_timer_interval = 1000; // "normal" speed is 60000. If 1000 : each second is a minute on timeline. 
+//var timeline_interval = 10000; // "normal" speed timer is 30 minutes (1800000 milliseconds); fast timer is 10 seconds (10000 milliseconds)
 var fire_interval = 180; // change back to 180
 var numIntervals = parseFloat(timeline_interval)/parseFloat(fire_interval);
 var increment = parseFloat(50)/parseFloat(numIntervals);

--- a/app/views/flash_teams/_globals.html.erb
+++ b/app/views/flash_teams/_globals.html.erb
@@ -11,4 +11,7 @@ var GDRIVE_DEV_KEY = '<%=ENV['GDRIVE_DEV_KEY']%>';
     
 var firebaseURL = '<%=ENV['FIREBASE_URL']%>';
 
+var task_timer_interval = '<%=ENV['TASK_TIMER_INTERVAL']%>';
+var timeline_interval = = '<%=ENV['TIMELINE_INTERVAL']%>';
+
 </script>

--- a/app/views/flash_teams/_globals.html.erb
+++ b/app/views/flash_teams/_globals.html.erb
@@ -12,6 +12,6 @@ var GDRIVE_DEV_KEY = '<%=ENV['GDRIVE_DEV_KEY']%>';
 var firebaseURL = '<%=ENV['FIREBASE_URL']%>';
 
 var task_timer_interval = '<%=ENV['TASK_TIMER_INTERVAL']%>';
-var timeline_interval = = '<%=ENV['TIMELINE_INTERVAL']%>';
+var timeline_interval = '<%=ENV['TIMELINE_INTERVAL']%>';
 
 </script>

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -14,7 +14,7 @@ namespace :notification do
    
 
    #default_url = 'foundry-app-dev.herokuapp.com'
-   default_url = ENV['DEFAULT_URL'].to_s
+   default_url = ENV['DEFAULT_URL']
    
    #script should be scheduled to run every call_period seconds
    call_period= 10 * 60 #seconds

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -14,7 +14,7 @@ namespace :notification do
    
 
    #default_url = 'foundry-app-dev.herokuapp.com'
-   default_url = ENV['DEFAULT_URL']
+   default_url = ENV['DEFAULT_URL'].to_s
    
    #script should be scheduled to run every call_period seconds
    call_period= 10 * 60 #seconds

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -13,7 +13,9 @@ namespace :notification do
    #default_url_options[:host] = 'localhost:3000'
    
 
-   default_url = 'foundry-app-dev.herokuapp.com'
+   #default_url = 'foundry-app-dev.herokuapp.com'
+   default_url = ENV['DEFAULT_URL']
+   
    #script should be scheduled to run every call_period seconds
    call_period= 10 * 60 #seconds
    puts "checking if a task is delayed..."

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -13,8 +13,8 @@ namespace :notification do
    #default_url_options[:host] = 'localhost:3000'
    
 
-   #default_url = 'foundry-app-dev.herokuapp.com'
-   default_url = ENV['DEFAULT_URL'].to_s
+   default_url = 'foundry-app-dev.herokuapp.com'
+   #default_url = ENV['DEFAULT_URL']
    
    #script should be scheduled to run every call_period seconds
    call_period= 10 * 60 #seconds

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -13,8 +13,8 @@ namespace :notification do
    #default_url_options[:host] = 'localhost:3000'
    
 
-   default_url = 'foundry-app-dev.herokuapp.com'
-   #default_url = ENV['DEFAULT_URL']
+   #default_url = 'foundry-app-dev.herokuapp.com'
+   default_url = ENV['DEFAULT_URL']
    
    #script should be scheduled to run every call_period seconds
    call_period= 10 * 60 #seconds


### PR DESCRIPTION
This PR moves the default_url, task_timer_interval, and timeline_interval variables to global ENV variables to make it easier to change their value for different dev and production environments in heroku.