### PR TITLE
Hide the cursor

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -54,7 +54,8 @@ var addCursor = function(){
         .attr("x2", 0)
         .attr("class", "cursor")
         .style("stroke", "red")
-        .style("stroke-width", "2");
+        .style("stroke-width", "2")
+        .style("display", "none");
 };
 
 var getXCoordForTime = function(t){


### PR DESCRIPTION
Quick fix. Didn't get rid of it, just set its display to none.

![screen shot 2015-01-17 at 3 05 42 am](https://cloud.githubusercontent.com/assets/6354033/5781410/c601a320-9df5-11e4-9e71-dc6a7be2c457.png)
