### PR TITLE
runtime bug: no task assigned to a worker.

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -1351,6 +1351,7 @@ var trackUpcomingEvent = function(){
        
         var overallTime;
         
+        if (currentUserEvents.length == 0 ) return;
         /*if (currentUserEvents.length <= 0) {
             overallTime = "You are not assigned to any tasks yet.";
             statusText.style("color", "black");      


### PR DESCRIPTION
When the worker is not assigned to any tasks a recurring error shows in he console of the workers page. The error referred to this line of code in the awareness.js:
var ev = flashTeamsJSON["events"][getEventJSONIndex(currentUserEvents[0].id)];

I just added one line of code and checked the status messages on the side bar. If you want to make sure everything works, follow the instructions here:
https://github.com/StanfordHCI/foundry/pull/181