### PR TITLE
added "The team is not started." to the sidebar.

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -262,6 +262,7 @@ function renderEverything(firstTime) {
             //console.log("flash team not in progress");
             
             if(flashTeamsJSON["startTime"] == undefined){
+                
 	            //console.log("NO START TIME!");
 				updateOriginalStatus();
             }
@@ -1404,7 +1405,9 @@ var trackUpcomingEvent = function(){
             statusText.style("color", "#40b8e4");
         }
         
-        
+        if(in_progress != true &&  (flashTeamsJSON["startTime"] == undefined) ){
+            overallTime = "The team is not started. " + overallTime;
+        }
         statusText.text(overallTime);
     }, fire_interval);
 }

--- a/app/assets/javascripts/authoring/sidebar.js
+++ b/app/assets/javascripts/authoring/sidebar.js
@@ -364,7 +364,10 @@ $(function() {
 /* --------------- PROJECT STATUS BAR START ------------ */
 var project_status_svg = d3.select("#status-bar-container").append("svg")
 .attr("width", "100%")
-.attr("height", 100);
+.attr("height", 100)
+.text("");
+
+
 
 var statusText = project_status_svg.append("foreignObject")
 .attr("x", 11)

--- a/app/views/flash_teams/_project_status.html.erb
+++ b/app/views/flash_teams/_project_status.html.erb
@@ -1,15 +1,15 @@
 <div style="padding: 0 11px;">
   <a target="_blank" id="gFolder" class="button">
     <div class="google-drive-button">
-      <span class="text">Go to Google Drive™ folder</span>
+      <span class="text">Google Drive™ folder</span>
     </div>
   </a>
-  <p style="font-weight: 400;margin-top: 11px;">Progress Status:</p>
+  <!--<p style="font-weight: 400;margin-top: 11px;">Progress Status:</p>
   <div class="progress progress-bar" style="background: #ffffff !important; border:solid 1px #c3c3c3;">
       <div class="bar" style=" width: 0%; transition:width 1s linear;
       -moz-transition:width 1s linear; 
       -webkit-transition:width 1s linear; 
       -o-transition:width 1s linear;" >
       </div>
-  </div>
+  </div> -->
 </div>


### PR DESCRIPTION
"The team is not started." in the sidebar tells the worker that the team is not started yet. 
The progress bar is commented out. We can bring it back when it works to replace and let it show up right after the team is started. 

Plus, I shortened the text  on the Google drive link in the sidebar. I removed the "Go to" part.