### PR TITLE
Dr email notif text

### DIFF
--- a/app/views/user_mailer/send_delayed_dri_not_responded.html.erb
+++ b/app/views/user_mailer/send_delayed_dri_not_responded.html.erb
@@ -5,8 +5,14 @@
   </head>
   <body>
     <h1><%= @event_name %> is not finished on time</h1>
+    
+    <p>Hi Team,</p>
     <p>   
-		Unfortunately, <%= @event_name %> by <%= @dri_role %> is not finished on time. We will notify you when the delayed task is finished or when we receive an estimation of the delay. 
+		This email is notifying you that unfortunately, the <%= @event_name %> task by <%= @dri_role %> was not finished on time. We will notify you when the delayed task is finished or when we receive an estimation of the delay. 
+    </p>
+    
+    <p>Sincerely, <br />
+	    The Foundry Team
     </p>
   </body>
 </html>

--- a/app/views/user_mailer/send_delayed_dri_not_responded.text.erb
+++ b/app/views/user_mailer/send_delayed_dri_not_responded.text.erb
@@ -1,4 +1,9 @@
 <%= @event_name %> is not finished on time
 ===============================================
  
-Unfortunately, <%= @event_name %> by <%= @dri_role %> is not finished on time. We will notify you when the delayed task is finished or when we receive an estimation of the delay. 
+Hi Team,
+
+This email is notifying you that unfortunately, the <%= @event_name %> task by <%= @dri_role %> was not finished on time. We will notify you when the delayed task is finished or when we receive an estimation of the delay. 
+
+Sincerely,
+The Foundry Team

--- a/app/views/user_mailer/send_delayed_task_finished_email.html.erb
+++ b/app/views/user_mailer/send_delayed_task_finished_email.html.erb
@@ -9,7 +9,7 @@
     <p>Hi Team, </p>
     
     <p>
-      We are pleased to let you know that the <%= @title %> task is finished. Your next upcoming task will begin in <%= @minutes %>. Please remember to log on to Foundry using the account link emailed to you in the beginning of the project and start your task once it is time. 
+      We are pleased to let you know that the <%= @title %> task, the previously delayed task, is now finished. Please remember to log on to Foundry using the account link emailed to you in the beginning of the project and start your task once it is time. 
       
       Thank you! 
     </p>

--- a/app/views/user_mailer/send_delayed_task_finished_email.html.erb
+++ b/app/views/user_mailer/send_delayed_task_finished_email.html.erb
@@ -5,10 +5,18 @@
   </head>
   <body>
     <h1><%= @title %> is finished</h1>
+    
+    <p>Hi Team, </p>
+    
     <p>
-      <%= @title %> is finished. Your next upcoming task will begin in <%= @minutes %>. 
- 
-
+      We are pleased to let you know that the <%= @title %> task is finished. Your next upcoming task will begin in <%= @minutes %>. Please remember to log on to Foundry using the account link emailed to you in the beginning of the project and start your task once it is time. 
+      
+      Thank you! 
     </p>
+
+    <p> Sincerely, <br />
+	    The Foundry Team 
+    </p>
+    
   </body>
 </html>

--- a/app/views/user_mailer/send_delayed_task_finished_email.text.erb
+++ b/app/views/user_mailer/send_delayed_task_finished_email.text.erb
@@ -1,4 +1,11 @@
 <%= @title %> is finished
 ===============================================
  
-<%= @title %> is finished. Your next upcoming task will begin in <%= @minutes %>. 
+Hi Team, 
+
+We are pleased to let you know that the <%= @title %> task is finished. Your next upcoming task will begin in <%= @minutes %>. Please remember to log on to Foundry using the account link emailed to you in the beginning of the project and start your task once it is time. 
+      
+Thank you! 
+
+Sincerely, 
+The Foundry Team 

--- a/app/views/user_mailer/send_dri_on_delay_email.html.erb
+++ b/app/views/user_mailer/send_dri_on_delay_email.html.erb
@@ -5,6 +5,10 @@
   </head>
   <body>
     <h1><%= @event_name %> is running late</h1>
+    
+    <p>
+	    Hi <%= @dri_role %>,
+    </p>
     <p>   
      Foundry must inform you that <%= @event_name %> is running late. Please click the link below and enter your estimate of how much longer you think it will take to finish the delayed task:  <%= @url %>. As soon as we receive your response, we will notify the other team members about the delay and the updated estimated completion time. If we do not hear back from you in <%= @minutes %> minutes, we will notify other team members anyway.
     </p>

--- a/app/views/user_mailer/send_dri_on_delay_email.html.erb
+++ b/app/views/user_mailer/send_dri_on_delay_email.html.erb
@@ -6,7 +6,11 @@
   <body>
     <h1><%= @event_name %> is running late</h1>
     <p>   
-     Foundry must inform you that <%= @event_name %> is running late. <%= link_to 'Please fill out this form', @url %> to give other team members an estimate of how long it takes to finish the delayed task. If we do not hear back from you in <%= @minutes %> minutes, we will notify other team members anyway.
+     Foundry must inform you that <%= @event_name %> is running late. Please click the link below and enter your estimate of how much longer you think it will take to finish the delayed task:  <%= @url %>. As soon as we receive your response, we will notify the other team members about the delay and the updated estimated completion time. If we do not hear back from you in <%= @minutes %> minutes, we will notify other team members anyway.
+    </p>
+    
+    <p> Sincerely, <br />
+	    The Foundry Team 
     </p>
     
   </body>

--- a/app/views/user_mailer/send_dri_on_delay_email.text.erb
+++ b/app/views/user_mailer/send_dri_on_delay_email.text.erb
@@ -1,6 +1,9 @@
-Flash Teams: <%= @event_name %> is running late
+<%= @event_name %> is running late
 ===============================================
- 
-Dear <%= @dri_role %>,
 
-Foundry must inform you that <%= @event_name %> is running late. <%= link_to 'Please fill out this form', @url %> to give other team members an estimate of how long it takes to finish the delayed task. If we do not hear back from you in <%= @minutes %> minutes, we will notify other team members anyway.
+Hi <%= @dri_role %>,
+    
+Foundry must inform you that <%= @event_name %> is running late. Please click the link below and enter your estimate of how much longer you think it will take to finish the delayed task:  <%= @url %>. As soon as we receive your response, we will notify the other team members about the delay and the updated estimated completion time. If we do not hear back from you in <%= @minutes %> minutes, we will notify other team members anyway.
+
+Sincerely, 
+The Foundry Team 

--- a/app/views/user_mailer/send_task_delayed_email.html.erb
+++ b/app/views/user_mailer/send_task_delayed_email.html.erb
@@ -5,8 +5,16 @@
   </head>
   <body>
     <h1><%= @event_name %> was not finished on time</h1>
+    
+    <p>Hi Team, </p>
+    
     <p>   
-		Unfortunately, <%= @event_name %> by <%= @dri_role %> was not finished on time and is expected to finish in <%= @delay_estimation %>. Flash Teams will notify you when it is done. 
+		This email is notifying you that unfortunately, the <%= @event_name %> task by <%= @dri_role %> was not finished on time and is expected to finish in <%= @delay_estimation %>. You will receive another email notification when the task has been completed. 
     </p>
+    
+    <p> Sincerely, <br />
+	    The Foundry Team 
+    </p>
+    
   </body>
 </html>

--- a/app/views/user_mailer/send_task_delayed_email.text.erb
+++ b/app/views/user_mailer/send_task_delayed_email.text.erb
@@ -1,4 +1,9 @@
 <%= @event_name %> was not finished on time
 ===============================================
- 
-Unfortunately, <%= @event_name %> by <%= @dri_role %> was not finished on time and is expected to finish in <%= @delay_estimation %>. Flash Teams will notify you when it is done. 
+     
+Hi Team,
+    
+This email is notifying you that unfortunately, the <%= @event_name %> task by <%= @dri_role %> was not finished on time and is expected to finish in <%= @delay_estimation %>. You will receive another email notification when the task has been completed. 
+
+Sincerely, 
+The Foundry Team 


### PR DESCRIPTION
I updated the text in the HTML and TXT version of the following emails: 

send_delayed_dri_not_responded.html.erb
send_delayed_task_finished_email.html.erb
send_dri_on_delay_email.html.erb
send_task_delayed.html.erb

Please review the text in the emails and make sure it makes sense and that there are no typos. Also, on emails to the DRI I started them with "Hi @dri_role" -- ideally it should really be the DRI's name instead of their role but I wasn't sure how to access that. Let me know your thoughts / if you want to change it to the name. 

Also, one other random question, do we not send out emails anymore when the tasks are completed early? I noticed we have the code for it but I don't think you worked on it in this latest email update? Let me know! 

I think you can merge this into master if you are happy with it and then merge it into your email branch. Let me know if that works :)  