### PR TITLE
Fixed delayed event timer

### DIFF
--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -677,9 +677,10 @@ if(!window._foundry) {
          */
         text: function(eventObj) {
             var time = eventObj.timer || eventObj.duration;
+            var sign = (time / Math.abs(time) < 0) ? "-" : "";
             
-            var hours = Math.floor(time / 60);
-            var minutes = time % 60;
+            var hours = Math.floor(Math.abs(time) / 60);
+            var minutes = Math.abs(time) % 60;
 
             var durationArray = [];
             if(hours !== 0) {
@@ -691,7 +692,7 @@ if(!window._foundry) {
                 durationArray.push(minutes + minStr);
             }
 
-            var timeStr = durationArray.join(" ");
+            var timeStr = sign + durationArray.join(" ");
             
             var clockAttrs = events.clock.attrs;
             


### PR DESCRIPTION
![screen shot 2015-02-11 at 1 18 40 am](https://cloud.githubusercontent.com/assets/6354033/6130953/2720738a-b18c-11e4-9ac3-25a5dbb8e6ed.png)

Accidentally called `Math.floor` on fraction values less than 0, pushing the hours count down to -1. Fixed here.
