### PR TITLE
event IDs are now based on the timestamp of when they were created

### DIFF
--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -227,14 +227,14 @@ function getDuration(leftX, rightX) {
 
 //task_startBtn_time and task_endBtn_time refer to the time when the start button and end button on the task is clicked.
 function createEventObj(snapPoint, duration) {
-    event_counter++;
+    event_counter++; //this was previously used to assign IDs to events but now we use the createEventId() function instead to make sure that IDs are unique within a team
     
     duration = duration || 60;
     
     var startTimeObj = getStartTime(snapPoint[0]);
   
     var newEvent = {
-        "title":"New Event", "id":event_counter, 
+        "title":"New Event", "id":createEventId(), 
         "x": snapPoint[0]-4, "min_x": snapPoint[0], "y": snapPoint[1], //NOTE: -4 on x is for 1/15/15 render of events
         "startTime": startTimeObj["startTimeinMinutes"], "duration":duration, 
         "members":[], timer:0, task_startBtn_time:-1, task_endBtn_time:-1,
@@ -254,6 +254,13 @@ if (flashTeamsJSON.events.length == 0 || !flashTeamsJSON.folder){
     
     return newEvent;
 };
+
+function createEventId(){
+	var timestamp = new Date();
+	event_timestamp = Math.floor(timestamp.getTime()/ 1000);
+	//console.log("eventId: " + event_timestamp);
+	return event_timestamp;
+}
 
 function getEventFromId(id) {
     var events = flashTeamsJSON.events;


### PR DESCRIPTION
This PR (hopefully) resolves issue #171 

The event IDs are now generated using a timestamp from when they were created. Currently, this uses the local time on the user's machine. When teams are duplicated, the new team's tasks will have the original timestamps, which I think is fine since the important thing is for all of the tasks in a team to be unique. Eventually we might want to assign unique IDs to all tasks but I don't think that is important right now. Also, I could imagine cases in which it might be useful for duplicated tasks to have the same ID across teams for things like the event library (so that we only show one version of the same task). Just thinking out loud here. 

Anyway, when testing, try deleting tasks, creating handoffs, deleting handoffs, duplicating teams, running a team and completing tasks, etc. I guess test it however you think it is best.