### PR TITLE
At int drag del

### DIFF
--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -482,7 +482,7 @@ function drawEachHandoffForEvent(eventObj){
             
             if (draw){
                 var task1end = ev1.startTime + ev1.duration;
-                if (task1end <= ev2.startTime) { //AT START HERE
+                if (task1end <= ev2.startTime) { 
                     //Reposition an existing handoff
                     var x1 = handoffStart(ev1);
                     var y1 = ev1.y + 50;
@@ -496,7 +496,7 @@ function drawEachHandoffForEvent(eventObj){
                             if (isWorkerInteraction(inter["id"])) return WORKER_TASK_NOT_START_COLOR;
                             else return "gray";
                         });
-                } else {
+                } else { //Out of range
                     $("#interaction_" + inter["id"]).fadeOut();
                     setTimeout(function() {
                         deleteInteraction(inter["id"]);
@@ -547,7 +547,7 @@ function drawEachCollabForEvent(eventObj){
                         .attr("y", firstTaskY-9) //AT hack to fix offset from tab members
                         .attr("height", taskDistance+9)
                         .attr("width", overlap);
-                } else {
+                } else { //Out of range
                     $("#interaction_" + inter["id"]).fadeOut();
                     setTimeout(function() {
                         deleteInteraction(inter["id"]);

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -44,6 +44,7 @@ var drag = d3.behavior.drag()
     .origin(Object)
     .on("drag", dragEventBlock)
     .on("dragend", function(d){
+        console.log("DONE DRAGGING");
         if(dragged){
             dragged = false;
             var ev = getEventFromId(d.groupNum);

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -54,16 +54,20 @@ var drag = d3.behavior.drag()
 
             //Check if handoffs will make this a bag drag
             var outOfRange = false;
+            var event1;
+            var event2;
             var eventHandoffs = getHandoffsForEvent(d.groupNum);
             for (var i = 0; i<eventHandoffs.length; i++) {
                 var handoff = flashTeamsJSON["interactions"][getIntJSONIndex(eventHandoffs[i])];
+                event1 = flashTeamsJSON["events"][getEventJSONIndex(handoff["event1"])];
+                event2 = flashTeamsJSON["events"][getEventJSONIndex(handoff["event2"])];
                 if (handoffOutOfRange(handoff["event1"], handoff["event2"]) == true) {
                     outOfRange = true;
                     break;
                 }
             } 
             if (outOfRange) {
-                alert("Sorry, an upstream event cannot end before a downstream event begins.");
+                alert("Sorry, " + event1.title + " cannot end before " + event2.title + " begins.");
                 flashTeamsJSON["events"][getEventJSONIndex(d.groupNum)] = originalEV;
                 drawEvent(originalEV, false);
             }
@@ -73,14 +77,16 @@ var drag = d3.behavior.drag()
             var eventCollabs = getCollabsForEvent(d.groupNum);
             for (var i = 0; i<eventCollabs.length; i++) {
                 var collab = flashTeamsJSON["interactions"][getIntJSONIndex(eventCollabs[i])];
-                var event1 = flashTeamsJSON["events"][getEventJSONIndex(collab.event1)];
-                var event2 = flashTeamsJSON["events"][getEventJSONIndex(collab.event2)];
+                event1 = flashTeamsJSON["events"][getEventJSONIndex(collab.event1)];
+                event2 = flashTeamsJSON["events"][getEventJSONIndex(collab.event2)];
                 var overlap = eventsOverlap(event1.x, getWidth(event1), event2.x, getWidth(event2));
                 
                 if (overlap <= 0) {
-                    alert("Sorry, the events must overlap to have a collaboration.");
+                    alert("Sorry, " + event1.title + " and " + event2.title 
+                        + " the must overlap to have a collaboration.");
                     flashTeamsJSON["events"][getEventJSONIndex(d.groupNum)] = originalEV;
                     drawEvent(originalEV, false);
+                    break;
                 }
             }
             

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -69,7 +69,20 @@ var drag = d3.behavior.drag()
             }
 
             //Check if collabs will make this a bad drag
-            
+            outOfRange = false;
+            var eventCollabs = getCollabsForEvent(d.groupNum);
+            for (var i = 0; i<eventCollabs.length; i++) {
+                var collab = flashTeamsJSON["interactions"][getIntJSONIndex(eventCollabs[i])];
+                var event1 = flashTeamsJSON["events"][getEventJSONIndex(collab.event1)];
+                var event2 = flashTeamsJSON["events"][getEventJSONIndex(collab.event2)];
+                var overlap = eventsOverlap(event1.x, getWidth(event1), event2.x, getWidth(event2));
+                
+                if (overlap <= 0) {
+                    alert("Sorry, the events must overlap to have a collaboration.");
+                    flashTeamsJSON["events"][getEventJSONIndex(d.groupNum)] = originalEV;
+                    drawEvent(originalEV, false);
+                }
+            }
             
             updateStatus(false);
         } else {
@@ -549,12 +562,7 @@ function drawEachCollabForEvent(eventObj){
                         .attr("y", firstTaskY-9) //AT hack to fix offset from tab members
                         .attr("height", taskDistance+9)
                         .attr("width", overlap);
-                } else { //Out of range
-                    $("#interaction_" + inter["id"]).fadeOut();
-                    setTimeout(function() {
-                        deleteInteraction(inter["id"]);
-                    }, 1000);
-                }
+                }      
             }
         }
     }

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -502,8 +502,6 @@ function drawEachHandoffForEvent(eventObj){
                         deleteInteraction(inter["id"]);
                     }, 1000);
                 }
-
-               
             }
         }
     }
@@ -533,20 +531,28 @@ function drawEachCollabForEvent(eventObj){
                 var firstTaskY = 0;
                 var taskDistance = 0;
                 var overlap = eventsOverlap(ev1.x, getWidth(ev1), ev2.x, getWidth(ev2));
-                if (y1 < y2) {
-                    firstTaskY = y1 + RECTANGLE_HEIGHT;
-                    taskDistance = y2 - firstTaskY;
+
+                if (overlap > 0) {
+                    if (y1 < y2) {
+                        firstTaskY = y1 + RECTANGLE_HEIGHT;
+                        taskDistance = y2 - firstTaskY;
+                    } else {
+                        firstTaskY = y2 + RECTANGLE_HEIGHT;
+                        taskDistance = y1 - firstTaskY;
+                    }
+                    if (x1 <= x2) var startX = x2;
+                    else var startX = x1;
+                    $("#interaction_" + inter["id"])
+                        .attr("x", startX)
+                        .attr("y", firstTaskY-9) //AT hack to fix offset from tab members
+                        .attr("height", taskDistance+9)
+                        .attr("width", overlap);
                 } else {
-                    firstTaskY = y2 + RECTANGLE_HEIGHT;
-                    taskDistance = y1 - firstTaskY;
+                    $("#interaction_" + inter["id"]).fadeOut();
+                    setTimeout(function() {
+                        deleteInteraction(inter["id"]);
+                    }, 1000);
                 }
-                if (x1 <= x2) var startX = x2;
-                else var startX = x1;
-                $("#interaction_" + inter["id"])
-                    .attr("x", startX)
-                    .attr("y", firstTaskY-9) //AT hack to fix offset from tab members
-                    .attr("height", taskDistance+9)
-                    .attr("width", overlap);
             }
         }
     }

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -83,7 +83,7 @@ var drag = d3.behavior.drag()
                 
                 if (overlap <= 0) {
                     alert("Sorry, " + event1.title + " and " + event2.title 
-                        + " the must overlap to have a collaboration.");
+                        + " must overlap to have a collaboration.");
                     flashTeamsJSON["events"][getEventJSONIndex(d.groupNum)] = originalEV;
                     drawEvent(originalEV, false);
                     break;

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -67,6 +67,10 @@ var drag = d3.behavior.drag()
                 flashTeamsJSON["events"][getEventJSONIndex(d.groupNum)] = originalEV;
                 drawEvent(originalEV, false);
             }
+
+            //Check if collabs will make this a bad drag
+            
+            
             updateStatus(false);
         } else {
             // click

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -481,19 +481,29 @@ function drawEachHandoffForEvent(eventObj){
             }  
             
             if (draw){
-                //Reposition an existing handoff
-                var x1 = handoffStart(ev1);
-                var y1 = ev1.y + 50;
-                var x2 = ev2.x + 3;
-                var y2 = ev2.y + 50;
-                $("#interaction_" + inter["id"])
-                    .attr("d", function(d) {
-                        return routeHandoffPath(ev1, ev2, x1, x2, y1, y2); 
-                    })
-                    .attr("stroke", function() {
-                        if (isWorkerInteraction(inter["id"])) return WORKER_TASK_NOT_START_COLOR;
-                        else return "gray";
-                    });
+                var task1end = ev1.startTime + ev1.duration;
+                if (task1end <= ev2.startTime) { //AT START HERE
+                    //Reposition an existing handoff
+                    var x1 = handoffStart(ev1);
+                    var y1 = ev1.y + 50;
+                    var x2 = ev2.x + 3;
+                    var y2 = ev2.y + 50;
+                    $("#interaction_" + inter["id"])
+                        .attr("d", function(d) {
+                            return routeHandoffPath(ev1, ev2, x1, x2, y1, y2); 
+                        })
+                        .attr("stroke", function() {
+                            if (isWorkerInteraction(inter["id"])) return WORKER_TASK_NOT_START_COLOR;
+                            else return "gray";
+                        });
+                } else {
+                    $("#interaction_" + inter["id"]).fadeOut();
+                    setTimeout(function() {
+                        deleteInteraction(inter["id"]);
+                    }, 1000);
+                }
+
+               
             }
         }
     }

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -52,7 +52,7 @@ var drag = d3.behavior.drag()
         } else {
             // click
             eventMousedown(d.groupNum);
-        }
+        } //AT - START HERE, IF BAD, POP BACK to original spot
     });
 
 // leftResize: resize the rectangle by dragging the left handle
@@ -497,10 +497,12 @@ function drawEachHandoffForEvent(eventObj){
                             else return "gray";
                         });
                 } else { //Out of range
+                    //alert("Bag drag");
                     $("#interaction_" + inter["id"]).fadeOut();
                     setTimeout(function() {
                         deleteInteraction(inter["id"]);
                     }, 1000);
+                    //bootstrap alert, put back in original space
                 }
             }
         }

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -560,6 +560,24 @@ function getHandoffsForEvent(id) {
     return eventHandoffs;
 }
 
+function getCollabsForEvent(id) {
+    var interactions = flashTeamsJSON["interactions"];
+    var eventCollabs = [];
+    for (var i = 0; i < interactions.length; i++){
+        var inter = interactions[i];
+        var belongs = false;
+        if (inter["type"] == "collaboration"){
+            if (inter["event1"] == id) belongs = true;
+            else if (inter["event2"] == id) belongs = true;
+            
+            if (belongs){
+                eventCollabs.push(inter["id"]);
+            }
+        }
+    }
+    return eventCollabs;
+}
+
 function handoffOutOfRange(ev1, ev2) {
     var event1 = flashTeamsJSON["events"][getEventJSONIndex(ev1)];
     var event2 = flashTeamsJSON["events"][getEventJSONIndex(ev2)];

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -94,7 +94,6 @@ function eventMousedown(task2idNum) {
             drawHandoff(handoffData);
             DRAWING_HANDOFF = false;
             $(".task_rectangle").popover("hide");
-            //d3.event.stopPropagation();
             INTERACTION_TASK_ONE_IDNUM = 0; // back to 0
         } else {
             alert("Sorry, the second task must begin after the first task ends.");
@@ -543,7 +542,7 @@ function isWorkerInteraction(id) {
     return false;
 }
 
-function retHandoffsForEvent(id) {
+function getHandoffsForEvent(id) {
     var interactions = flashTeamsJSON["interactions"];
     var eventHandoffs = [];
     for (var i = 0; i < interactions.length; i++){
@@ -561,7 +560,10 @@ function retHandoffsForEvent(id) {
     return eventHandoffs;
 }
 
-function handoffOutOfRange() {
-
-
+function handoffOutOfRange(ev1, ev2) {
+    var event1 = flashTeamsJSON["events"][getEventJSONIndex(ev1)];
+    var event2 = flashTeamsJSON["events"][getEventJSONIndex(ev2)];
+     var task1End = event1.startTime + event1.duration;
+     if (task1End > event2.startTime) return true;
+     else return false;
 }

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -543,4 +543,25 @@ function isWorkerInteraction(id) {
     return false;
 }
 
+function retHandoffsForEvent(id) {
+    var interactions = flashTeamsJSON["interactions"];
+    var eventHandoffs = [];
+    for (var i = 0; i < interactions.length; i++){
+        var inter = interactions[i];
+        var belongs = false;
+        if (inter["type"] == "handoff"){
+            if (inter["event1"] == id) belongs = true;
+            else if (inter["event2"] == id) belongs = true;
+            
+            if (belongs){
+                eventHandoffs.push(inter["id"]);
+            }
+        }
+    }
+    return eventHandoffs;
+}
 
+function handoffOutOfRange() {
+
+
+}


### PR DESCRIPTION
Should close #120 

When an event is dragged out of range for a collaboration or handoff, the interaction slowly fades out and then is deleted. 

The reason we are doing this and not an alert dialog is that when you do an alert dialog, the drag doesn't stop and the event drags all over the screen when you close the alert. This is more elegant. 

Part of the review is to make sure this semantically makes sense for a user. If they drag the event out of range the interaction goes away and doesn't come back if you drag back into range. 

Just draw lots of events, collabs, and handoffs. Make sure the definition of "out of range" seems correct, things are actually deleting, and that they don't come back after refresh or anything else. 