### PR TITLE
Dr task modal

### DIFF
--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -303,7 +303,7 @@ function getTaskOverviewContent(groupNum){
     content += '<div class="row-fluid" >';	
 				
 				if(ev.inputs) {
-					content += '<br /><h5>You should review the following deliverables from previous tasks: </h5>';
+					content += '<br /><h5>Review the following deliverables from previous tasks: </h5>';
 					//content += '<b>Inputs:</b><br>';
 					var inputs = ev.inputs.split(",");
 					for(var i=0;i<inputs.length;i++){

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -233,7 +233,190 @@ function getTaskOverviewForm(groupNum){
 
 }
 
+
 function getTaskOverviewContent(groupNum){
+	var task_id = getEventJSONIndex(groupNum);
+	var ev = flashTeamsJSON["events"][task_id];
+	
+	var hrs = Math.floor(ev.duration/60);
+    var mins = ev.duration % 60;
+    
+    // if the minutes are < 10, you need to add a zero before
+    if(mins < 10){
+	    mins = '0' + mins;
+    }
+    
+    var evStartHr = ev.startHr; 
+	var evStartMin = ev.startMin.toFixed(0); 
+	
+	// if the minutes are < 10, you need to add a zero before
+	if(evStartMin < 10){
+	    evStartMin = '0' + evStartMin;
+    }
+	
+	var content = '<div class="row-fluid" >';
+	
+		content += '<div class="span9">';
+		
+			content += '<h4>The goal of this task is to: </h4>';
+		
+			if (ev.notes != ""){
+				content += ev.notes;	
+			}
+			else{
+				content += "No task description has been provided yet."
+			}
+			
+		content += '</div>';
+		
+		content += '<div class="span3"><b>Duration: ' + hrs+':'+mins +'</b></div>';
+		
+	content += '</div>';
+		
+	content += '<div class="row-fluid" >';
+		
+		if(ev.outputs) {
+			//content += '<b>Deliverables:</b><br>';
+			content +=  '<br /><h5>Specifically, you must produce the following deliverables: </h5>';
+			var outputs = ev.outputs.split(",");
+			for(var i=0;i<outputs.length;i++){
+				
+				content += outputs[i];
+				
+				//content += outputs[i] + ': ';
+				//content += 'insert description here';
+				content += "<br />";
+			}
+		}
+    			
+    content += '</div>';
+    
+    content += '<div class="row-fluid" >';	
+				
+				if(ev.inputs) {
+					content += '<br /><h5>You will be provided with the following inputs: </h5>';
+					//content += '<b>Inputs:</b><br>';
+					var inputs = ev.inputs.split(",");
+					for(var i=0;i<inputs.length;i++){
+						content += inputs[i];
+					content += "<br />";
+        		}
+    }
+		content +=  '</div>'; 
+		
+		content += "<hr/>";
+		
+	content += '<div class="row-fluid" >';		
+				
+		content += '<b>Members assigned to this task: </b>';
+		
+		var num_members = ev.members.length;
+	    if(num_members > 0){
+	        //content += '<b>Members:</b><br>';
+	        for (var j=0;j<num_members-1;j++){
+	            var member = getMemberById(ev.members[j]);
+	            content += member.role;
+	            content += ', ';
+	        }
+	        var member = getMemberById(ev.members[num_members-1]);
+	        content += member.role;
+	        content += '<br/>';
+	    }
+	    else{
+		    content += "No members have been assigned yet."
+	    }
+    
+    if (ev.dri != "" && ev.dri != undefined){
+        var dri_id = parseInt (ev.dri);
+        var mem = null;
+
+        for (var i = 0; i<flashTeamsJSON["members"].length; i++){
+           
+            if(flashTeamsJSON["members"][i].id == dri_id){
+                mem = flashTeamsJSON["members"][i].role;
+                break;
+            }
+        }
+
+        if(mem && mem != undefined){
+            content += '<div class=row-fluid>';
+            content += '<b>Directly-Responsible Individual: </b>';
+            content += mem;
+            content += '</div>'
+        }
+    }
+    else{
+
+    }
+		
+		  if (ev.pc != "" && ev.pc != undefined){
+	        var pc_id = parseInt (ev.pc);
+	        var mem = null;
+	
+	        for (var i = 0; i<flashTeamsJSON["members"].length; i++){
+	           
+	            if(flashTeamsJSON["members"][i].id == pc_id){
+	                mem = flashTeamsJSON["members"][i].role;
+	                break;
+	            }
+	        }
+          if(mem && mem != undefined){
+            content += '<div class=row-fluid>'
+            content += '<b>Project Coordinator: </b>';
+            content += mem;
+            content += "</div>"
+            
+        }
+    }
+    else{
+
+    }
+
+     
+		
+	content += '</div>';
+		
+	content += "<hr/>";
+		
+		
+		
+	content += '<div class="row-fluid" >';	
+		
+		//content += "<hr/>";
+    content += "<h4>You will need to answer the following questions: <br /><br /></h4>";
+
+    //Add output documentation questions to task modal    
+    for (var key in ev.outputQs){
+        if (key != ""){
+            content += "<b><i>" + key + "</i></b></br>";
+            keyArray = ev.outputQs[key];
+            for (i = 0; i < keyArray.length; i++){
+                content += "<p><i>" + keyArray[i][0] + "</i></br>" + keyArray[i][1] + "</p>";
+            }
+            content += "<br />";
+        }
+    }
+    //content += "<hr/>";
+    
+
+    //Add general documentation questions to task modal
+    if (ev.docQs.length > 0){
+        docQs = ev.docQs;
+        for (i = 0; i < docQs.length; i++){
+            if (docQs[i][1] != null){
+                content += "<b><i>" + docQs[i][0] + " </i></b>";
+                content += "<p>" + docQs[i][1] + "</p><br />";
+            }
+        }
+    }
+    
+    content += '</div>';
+	
+	return content;
+}
+
+
+function getTaskOverviewContentOld(groupNum){
 	var task_id = getEventJSONIndex(groupNum);
 	var ev = flashTeamsJSON["events"][task_id];
 

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -269,7 +269,16 @@ function getTaskOverviewContent(groupNum){
 			
 		content += '</div>';
 		
-		content += '<div class="span3"><b>Duration: ' + hrs+':'+mins +'</b></div>';
+		content += '<div class="span3"><b>Duration: </b>' + hrs+':'+mins +'<br />'
+				+ '<b>Status: </b>'; 
+				
+				if(ev.status == "not_started"){
+					content += "not started";
+				}
+				else{
+					content += ev.status;
+				}
+		content += '</div>';
 		
 	content += '</div>';
 		
@@ -294,7 +303,7 @@ function getTaskOverviewContent(groupNum){
     content += '<div class="row-fluid" >';	
 				
 				if(ev.inputs) {
-					content += '<br /><h5>You will be provided with the following inputs: </h5>';
+					content += '<br /><h5>You will be provided with the following inputs, which you should review: </h5>';
 					//content += '<b>Inputs:</b><br>';
 					var inputs = ev.inputs.split(",");
 					for(var i=0;i<inputs.length;i++){
@@ -345,9 +354,7 @@ function getTaskOverviewContent(groupNum){
             content += '</div>'
         }
     }
-    else{
-
-    }
+   
 		
 		  if (ev.pc != "" && ev.pc != undefined){
 	        var pc_id = parseInt (ev.pc);
@@ -368,12 +375,8 @@ function getTaskOverviewContent(groupNum){
             
         }
     }
-    else{
+    
 
-    }
-
-     
-		
 	content += '</div>';
 		
 	content += "<hr/>";
@@ -382,7 +385,7 @@ function getTaskOverviewContent(groupNum){
 		
 	content += '<div class="row-fluid" >';	
 		
-		//content += "<hr/>";
+	//content += "<hr/>";
     content += "<h4>You will need to answer the following questions: <br /><br /></h4>";
 
     //Add output documentation questions to task modal    
@@ -416,6 +419,7 @@ function getTaskOverviewContent(groupNum){
 }
 
 
+//this was the previous task overview content that used the old modal layout 
 function getTaskOverviewContentOld(groupNum){
 	var task_id = getEventJSONIndex(groupNum);
 	var ev = flashTeamsJSON["events"][task_id];

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -286,7 +286,7 @@ function getTaskOverviewContent(groupNum){
 		
 		if(ev.outputs) {
 			//content += '<b>Deliverables:</b><br>';
-			content +=  '<br /><h5>Specifically, you must produce the following deliverables: </h5>';
+			content +=  '<br /><h5>Specifically, you are expected produce the following deliverables: </h5>';
 			var outputs = ev.outputs.split(",");
 			for(var i=0;i<outputs.length;i++){
 				
@@ -303,7 +303,7 @@ function getTaskOverviewContent(groupNum){
     content += '<div class="row-fluid" >';	
 				
 				if(ev.inputs) {
-					content += '<br /><h5>You will be provided with the following inputs, which you should review: </h5>';
+					content += '<br /><h5>You should review the following deliverables from previous tasks: </h5>';
 					//content += '<b>Inputs:</b><br>';
 					var inputs = ev.inputs.split(",");
 					for(var i=0;i<inputs.length;i++){
@@ -419,7 +419,7 @@ function getTaskOverviewContent(groupNum){
 }
 
 
-//this was the previous task overview content that used the old modal layout 
+//this was the previous task overview content that used the old modal layout (can be erased once we confirm we like new modal)
 function getTaskOverviewContentOld(groupNum){
 	var task_id = getEventJSONIndex(groupNum);
 	var ev = flashTeamsJSON["events"][task_id];

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -256,7 +256,7 @@ function getTaskOverviewContent(groupNum){
 	
 	var content = '<div class="row-fluid" >';
 	
-		content += '<div class="span9">';
+		content += '<div class="span8">';
 		
 			content += '<h4>The goal of this task is to: </h4>';
 		
@@ -269,7 +269,7 @@ function getTaskOverviewContent(groupNum){
 			
 		content += '</div>';
 		
-		content += '<div class="span3"><b>Duration: </b>' + hrs+':'+mins +'<br />'
+		content += '<div class="span4"><b>Duration: </b>' + hrs+':'+mins +'<br />'
 				+ '<b>Status: </b>'; 
 				
 				if(ev.status == "not_started"){
@@ -286,7 +286,7 @@ function getTaskOverviewContent(groupNum){
 		
 		if(ev.outputs) {
 			//content += '<b>Deliverables:</b><br>';
-			content +=  '<br /><h5>Specifically, you are expected produce the following deliverables: </h5>';
+			content +=  '<br /><h5>Specifically, you are expected to produce the following deliverables: </h5>';
 			var outputs = ev.outputs.split(",");
 			for(var i=0;i<outputs.length;i++){
 				

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -13,6 +13,10 @@ video{
 	height: 180px;
 }
 
+hr{
+	margin: 10px 0;
+}
+
 #confirmEnd {
 	color: black;
 	width: 350px;


### PR DESCRIPTION
Updated the "read only" version of the modal to make it easier to read and interpret. 

When it is populated and before it is started: 
![image](https://cloud.githubusercontent.com/assets/5275384/6359886/f33cc61e-bc2a-11e4-8944-45a5385a6850.png)

When a task has just been created (i.e. no information has been entered yet): 
![image](https://cloud.githubusercontent.com/assets/5275384/6359902/0dafc096-bc2b-11e4-98b7-0e4477d49f7a.png)

When a task is in progress [note how the status text in the top right of the modal updates to in progress]: 
![image](https://cloud.githubusercontent.com/assets/5275384/6359919/248627f6-bc2b-11e4-8f4f-7753f50f7c50.png)

Completion modal where worker answers the documentation question (this is the same as before, no changes were made): 
![image](https://cloud.githubusercontent.com/assets/5275384/6359942/3f48e4c0-bc2b-11e4-82cb-c639dc7e8936.png)

When some questions have been answered but modal hasn't been submitted yet: 
![image](https://cloud.githubusercontent.com/assets/5275384/6359957/59ca45d2-bc2b-11e4-8790-580cc33d07b6.png)

When task has been completed (note how the status text in the top right changes to completed):
![image](https://cloud.githubusercontent.com/assets/5275384/6359965/6cdd142e-bc2b-11e4-85c8-784e0514b296.png)

When testing: 
1) Make sure modals appear correctly in both worker and author view.
2) Test creating tasks with different amounts of information entered. Make sure none of the formatting is messed up when certain content is excluded. 
3) Check that the content makes sense / information flow looks good. 

For now, we decided that this is better then what is currently there. The next steps, however, include: (to be done in future PR): 
1) Update the inputs to list the previous tasks (using the dependencies/handoffs instead of manually entering inputs). These inputs/tasks will be links to their respective google drive folders. 
2) Potentially restructuring inputs and outputs -- TBD. 
