### PR TITLE
Nr fix input link

### DIFF
--- a/app/assets/javascripts/authoring/dependencies.js
+++ b/app/assets/javascripts/authoring/dependencies.js
@@ -156,9 +156,29 @@ function events_immediately_before(groupNum){
  var ids_immediately_before=[];
  var interactions = flashTeamsJSON["interactions"];
  for(var i = 0; i<interactions.length; i++){
+ 	if(interactions[i].type != "handoff")
+ 		continue;
  	if (parseInt(interactions[i].event2) == groupNum){
  		ids_immediately_before.push(parseInt(interactions[i].event1));
  	}	
  }
  return ids_immediately_before;
+}
+
+function events_in_collaboration(groupNum){
+	var collab_ids=[];
+	var interactions = flashTeamsJSON["interactions"];
+	for(var i = 0; i<interactions.length; i++){
+		if(interactions[i].type != "collaboration")
+			continue;
+
+	 	if (parseInt(interactions[i].event2) == groupNum){
+	 		collab_ids.push(parseInt(interactions[i].event1));
+	 	}
+	 	
+	 	else if (parseInt(interactions[i].event1) == groupNum){
+	 		collab_ids.push(parseInt(interactions[i].event2));
+	 	}	
+ 	}
+ 	return collab_ids;
 }

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -239,7 +239,7 @@ function createEventObj(snapPoint, duration) {
         "startTime": startTimeObj["startTimeinMinutes"], "duration":duration, 
         "members":[], timer:0, task_startBtn_time:-1, task_endBtn_time:-1,
         "dri":"", "pc":"", "notes":"", "startHr": startTimeObj["startHr"], "status":"not_started",
-        "startMin": startTimeObj["startMin"], "gdrive":[], "completed_x":null, "inputs":"", "outputs":"", events_after : "",
+        "startMin": startTimeObj["startMin"], "gdrive":[], "completed_x":null, "inputs":"", "all_inputs":"", "outputs":"", events_after : "",
         "docQs": [["Please explain all other design or execution decisions made, along with the reason they were made",""], 
         ["Please add anything else you want other team members, the project coordinator, or the client, to know. (optional)",""]],
         "outputQs":{},"row": Math.floor((snapPoint[1]-5)/_foundry.timeline.rowHeight)};

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -692,7 +692,10 @@ function saveTaskOverview(groupNum){
             } 
         }
     }
-    ev.outputQs = outQs;
+    ev.outputQs = outQs;    
+
+    //everytime a modal is saved all_inputs of all events on the timeline are updated
+    update_all_inputs_string();
 
     drawEvent(ev);
     updateStatus();
@@ -700,3 +703,23 @@ function saveTaskOverview(groupNum){
     $('#task_modal').modal('hide'); 
 }
 
+
+//this function updates all the inputs of all tasks based on previous tasks' outputs
+function update_all_inputs_string(){
+    var events = flashTeamsJSON["events"];
+    var all_inputs_array=[];
+    
+    for (var i =0; i<events.length; i++){
+        var all_inputs_string="";
+        all_inputs_array = getAllInputs(events[i].id);
+        for( var j=0; j<all_inputs_array.length; j++){
+            if (j==0)
+                all_inputs_string +=String(all_inputs_array[j][1]);
+            else
+                all_inputs_string +=','+ String(all_inputs_array[j][1]);
+
+            flashTeamsJSON["events"][i]["all_inputs"] = all_inputs_string;
+        }
+        
+    }
+}

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -306,7 +306,7 @@ function getTaskOverviewContent(groupNum){
     var all_inputs = getAllInputs(groupNum);
 
     if(all_inputs.length!=0) {
-		content += '<br /><h5>Review the following deliverables from previous tasks: </h5>';
+		content += '<br /><h5>Review the following deliverables: </h5>';
 		for(var i=0; i<all_inputs.length; i++){
                 input_ev_id = all_inputs[i][0];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -301,13 +301,19 @@ function getTaskOverviewContent(groupNum){
     content += '</div>';
     
     content += '<div class="row-fluid" >';	
-	var events_before_ids = events_immediately_before(groupNum);
+	//var events_before_ids = events_immediately_before(groupNum);
 	
-    if(ev.inputs || (events_before_ids.length!=0)) { //todo here
+    var all_inputs = getAllInputs(groupNum);
 
+    if(all_inputs.length!=0) {
 		content += '<br /><h5>Review the following deliverables from previous tasks: </h5>';
-		//content += '<b>Inputs:</b><br>';
-		var inputs = ev.inputs.split(",");
+		for(var i=0; i<all_inputs.length; i++){
+                input_ev_id = all_inputs[i][0];
+                var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+                content += "<a href=" + input_ev["gdrive"][1] + " target='_blank'>"+ all_inputs[i][1] +"</a></br>";
+        }
+        //content += '<b>Inputs:</b><br>';
+		/*var inputs = ev.inputs.split(",");
 		for(var i=0;i<inputs.length;i++){
 			content += "<a href=" + ev["gdrive"][1] + " target='_blank'>"+ inputs[i] +"</a></br>";
         }
@@ -321,8 +327,7 @@ function getTaskOverviewContent(groupNum){
             for(var j=0;j<outputs.length;j++){   
                 content += "<a href=" + ev_before["gdrive"][1] + " target='_blank'>"+ outputs[j] + "</a></br>";
             }					
-	    }
-      
+	    } */   
     }
 		content +=  '</div>'; 
 		
@@ -431,6 +436,40 @@ function getTaskOverviewContent(groupNum){
 	return content;
 }
 
+//returns an array of inputs of the task including the current task inputs and the previous tasks' outputs.
+// getAllInputs returns: [[task_id, input]]
+function getAllInputs(groupNum){
+   var task_id = getEventJSONIndex(groupNum);
+   var ev = flashTeamsJSON["events"][task_id];
+
+   var events_before_ids = events_immediately_before(groupNum);
+    
+   var all_inputs=[];
+
+   if(ev.inputs) { 
+
+        var inputs = ev.inputs.split(",");
+        for(var i=0;i<inputs.length;i++){
+            all_inputs.push([groupNum, inputs[i] ]);    
+        }
+    }
+
+    if(events_before_ids.length!=0){
+        for(var i=0;i<events_before_ids.length;i++){
+           
+            var ev_before = flashTeamsJSON["events"][getEventJSONIndex(events_before_ids[i])];
+            if(ev_before["outputs"] =="" || ev_before["outputs"] == undefined)
+                continue;
+
+            var outputs = ev_before["outputs"].split(",");
+            
+            for(var j=0;j<outputs.length;j++){   
+               all_inputs.push([ev_before.id , outputs[j] ])
+            }                   
+        }    
+    }
+    return all_inputs;
+}
 
 //this was the previous task overview content that used the old modal layout (can be erased once we confirm we like new modal)
 function getTaskOverviewContentOld(groupNum){

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -436,40 +436,7 @@ function getTaskOverviewContent(groupNum){
 	return content;
 }
 
-//returns an array of inputs of the task including the current task inputs and the previous tasks' outputs.
-// getAllInputs returns: [[task_id, input]]
-function getAllInputs(groupNum){
-   var task_id = getEventJSONIndex(groupNum);
-   var ev = flashTeamsJSON["events"][task_id];
 
-   var events_before_ids = events_immediately_before(groupNum);
-    
-   var all_inputs=[];
-
-   if(ev.inputs) { 
-
-        var inputs = ev.inputs.split(",");
-        for(var i=0;i<inputs.length;i++){
-            all_inputs.push([groupNum, inputs[i] ]);    
-        }
-    }
-
-    if(events_before_ids.length!=0){
-        for(var i=0;i<events_before_ids.length;i++){
-           
-            var ev_before = flashTeamsJSON["events"][getEventJSONIndex(events_before_ids[i])];
-            if(ev_before["outputs"] =="" || ev_before["outputs"] == undefined)
-                continue;
-
-            var outputs = ev_before["outputs"].split(",");
-            
-            for(var j=0;j<outputs.length;j++){   
-               all_inputs.push([ev_before.id , outputs[j] ])
-            }                   
-        }    
-    }
-    return all_inputs;
-}
 
 //this was the previous task overview content that used the old modal layout (can be erased once we confirm we like new modal)
 function getTaskOverviewContentOld(groupNum){
@@ -722,4 +689,55 @@ function update_all_inputs_string(){
         }
         
     }
+}
+
+//returns an array of inputs of the task including the current task inputs and the previous tasks' outputs.
+// getAllInputs returns: [[task_id, input]]
+function getAllInputs(groupNum){
+   var task_id = getEventJSONIndex(groupNum);
+   var ev = flashTeamsJSON["events"][task_id];
+
+   var events_before_ids = events_immediately_before(groupNum);
+   var collaboration_ids = events_in_collaboration(groupNum);
+   var all_inputs=[];
+
+   if(ev.inputs) { 
+
+        var inputs = ev.inputs.split(",");
+        for(var i=0;i<inputs.length;i++){
+            all_inputs.push([groupNum, inputs[i] ]);    
+        }
+    }
+
+    if(events_before_ids.length!=0){
+        for(var i=0;i<events_before_ids.length;i++){
+           
+            var ev_before = flashTeamsJSON["events"][getEventJSONIndex(events_before_ids[i])];
+            if(ev_before["outputs"] =="" || ev_before["outputs"] == undefined)
+                continue;
+
+            var outputs = ev_before["outputs"].split(",");
+            
+            for(var j=0;j<outputs.length;j++){   
+               all_inputs.push([ev_before.id , outputs[j] ])
+            }                   
+        }    
+    }
+
+    if(collaboration_ids.length!=0){
+        for(var i=0;i<collaboration_ids.length;i++){
+           
+            var ev_collab = flashTeamsJSON["events"][getEventJSONIndex(collaboration_ids[i])];
+            if(ev_collab["outputs"] =="" || ev_collab["outputs"] == undefined)
+                continue;
+
+            var outputs = ev_collab["outputs"].split(",");
+            
+            for(var j=0;j<outputs.length;j++){   
+               all_inputs.push([ev_collab.id , outputs[j] ])
+            }                   
+        }   
+    }
+
+    return all_inputs;
 }

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -561,7 +561,7 @@ end
    		@task_description = params[:task_description]
    		
    		
-   		@inputs = params[:inputs]
+   		@all_inputs = params[:all_inputs]
    		@input_link = params[:input_link]
    		
    		@outputs = params[:outputs]
@@ -573,7 +573,7 @@ end
    		
    		#@message = "<p>This is an email from the Stanford HCI Group notifying you that a job requiring a #{@task_member} for the #{@task_name} task for the #{@flash_team_json['title']} project has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within the specified deadline.</p>"
    		
-   		UserMailer.send_task_hiring_email(@sender_email, @recipient_email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @task_duration).deliver
+   		UserMailer.send_task_hiring_email(@sender_email, @recipient_email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration).deliver
    
    end
    
@@ -655,7 +655,7 @@ end
    		@task_description = params[:task_description]
    		
    		
-   		@inputs = params[:inputs]
+   		@all_inputs = params[:all_inputs]
    		@input_link = params[:input_link]
    		
    		@outputs = params[:outputs]
@@ -664,7 +664,7 @@ end
    		@foundry_url = params[:foundry_url]
 
    		
-   		UserMailer.send_task_acceptance_email(@sender_email, @recipient_email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @task_duration, @foundry_url).deliver
+   		UserMailer.send_task_acceptance_email(@sender_email, @recipient_email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @foundry_url).deliver
    
    end
    

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -54,7 +54,7 @@ class UserMailer < ActionMailer::Base
   end
   
   
-  def send_task_hiring_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, inputs, input_link, outputs, output_description, task_duration)
+  def send_task_hiring_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration)
   
   	#@message = message.html_safe
   	@flash_team_name = flash_team_name
@@ -62,7 +62,7 @@ class UserMailer < ActionMailer::Base
   	@task_name = task_name
   	@project_overview = project_overview
   	@task_description = task_description
-  	@inputs = inputs
+  	@all_inputs = all_inputs
   	@input_link = input_link
   	@outputs = outputs
   	@output_description = output_description
@@ -71,7 +71,7 @@ class UserMailer < ActionMailer::Base
   	mail(:from => sender_email, :bcc => recipient_email, :subject => subject)
   end
   
-  def send_task_acceptance_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, inputs, input_link, outputs, output_description, task_duration, foundry_url)
+  def send_task_acceptance_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration, foundry_url)
   
   	#@message = message.html_safe
   	@flash_team_name = flash_team_name
@@ -79,7 +79,7 @@ class UserMailer < ActionMailer::Base
   	@task_name = task_name
   	@project_overview = project_overview
   	@task_description = task_description
-  	@inputs = inputs
+  	@all_inputs = all_inputs
   	@input_link = input_link
   	@outputs = outputs
   	@output_description = output_description

--- a/app/views/flash_teams/_task_acceptance_content.html.erb
+++ b/app/views/flash_teams/_task_acceptance_content.html.erb
@@ -73,9 +73,9 @@
 		            <div class="row-fluid span12">
 						<div class="span11">				
 							<p>
-								<%= label_tag(:inputs, "Input(s):") %>
+								<%= label_tag(:all_inputs, "Input(s):") %>
 								For this task, you will receive the following input(s):
-								<%= text_field_tag(:inputs, @flash_team_event['inputs'], :class => 'span6') %>. You can access the input(s) at the following link:
+								<%= text_field_tag(:all_inputs, @flash_team_event['all_inputs'], :class => 'span6') %>. You can access the input(s) at the following link:
 								<%= text_field_tag(:input_link, "", :placeholder => "OPTIONAL: [INSERT LINK TO INPUT]", :class => 'span10') %>
 							</p>
 						</div>

--- a/app/views/flash_teams/_task_acceptance_email_content.html.erb
+++ b/app/views/flash_teams/_task_acceptance_email_content.html.erb
@@ -22,7 +22,7 @@
 						<p><b>Task description:</b> <%=@task_description.html_safe%></p>
 						
 						<p>
-							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@inputs%> 
+							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@all_inputs%> 
 						
 						<%if !@input_link.empty?%>
 						You can access the input(s) at the following link: <a href="<%=@input_link%>"><%=@input_link%></a>

--- a/app/views/flash_teams/_task_available_content.html.erb
+++ b/app/views/flash_teams/_task_available_content.html.erb
@@ -76,9 +76,9 @@
 		            <div class="row-fluid span12">
 						<div class="span11">				
 							<p>
-								<%= label_tag(:inputs, "Input(s):") %>
+								<%= label_tag(:all_inputs, "Input(s):") %>
 								For this task, you will receive the following input(s):
-								<%= text_field_tag(:inputs, @flash_team_event['inputs'], :class => 'span6') %>. You can access the input(s) at the following link:
+								<%= text_field_tag(:all_inputs, @flash_team_event['all_inputs'], :class => 'span6') %>. You can access the input(s) at the following link:
 								<%= text_field_tag(:input_link, "", :placeholder => "OPTIONAL: [INSERT LINK TO INPUT]", :class => 'span12') %>
 							</p>
 						</div>

--- a/app/views/flash_teams/_task_available_email_content.html.erb
+++ b/app/views/flash_teams/_task_available_email_content.html.erb
@@ -20,7 +20,7 @@
 						<p><b>Task description:</b> <%=@task_description.html_safe%></p>
 						
 						<p>
-							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@inputs%>. 
+							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@all_inputs%>. 
 						
 						<%if !@input_link.empty?%>
 							You can access the input(s) at the following link: <a href="<%=@input_link%>"><%=@input_link%></a>


### PR DESCRIPTION
The "review the inputs..." line doesn't show up when the task has no inputs. 

There are no weird line breaks any more. 

The outputs from the events in collaboration are added to the inputs of the current event. 

The inputs are in the hiring emails. 

I had to add "all_inputs" array each event's json. This array keeps all the inputs of each event in this format: [groupNum, event]. When ever a task modal is saved, all_inputs is updated for all events on the timeline. 

Could you check the parts of the code related to the hiring emails?  

I checked the hiring emails locally but I couldn't check them on heroku because the panels didn't show up! I am not sure why. This is the error I get:
![image](https://cloud.githubusercontent.com/assets/6335320/6422803/b9d6e0a8-be91-11e4-8bd5-22db486f445e.png)