### PR TITLE
Kartik hiring documentation

### DIFF
--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -145,9 +145,21 @@ class LandingsController < ApplicationController
       @newLanding.end_date_time = @end_date_time + wait_time
       @newLanding.queuePosition = @queuePosition
       @newLanding.status = 'p'
+      if @queuePosition == 1 
+        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink)
+        @newLanding.emailSent = true
+        @newLanding.emailSentTime = Time.now
+      end
       @newLanding.uniq = @uniq
       @newLanding.save 
     else
+      @relevantLanding = Landing.where(:id_team=>@id_team, :id_event=>@id_task, :task_member=>@task_member, :status=>'p').order('created_at')
+      if @queuePosition == 1 and not(@relevantLanding[0].emailSent)
+        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink)
+        @relevantLanding[0].emailSent = true
+        @relevantLanding[0].emailSentTime = Time.now
+        @relevantLanding[0].save
+      end
       return
     end
   @relevantLanding = Landing.where(:id_team=>@id_team, :id_event=>@id_task, :task_member=>@task_member, :status=>'p').order('created_at')

--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -146,7 +146,7 @@ class LandingsController < ApplicationController
       @newLanding.queuePosition = @queuePosition
       @newLanding.status = 'p'
       if @queuePosition == 1 
-        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink)
+        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink).deliver
         @newLanding.emailSent = true
         @newLanding.emailSentTime = Time.now
       end
@@ -155,7 +155,7 @@ class LandingsController < ApplicationController
     else
       @relevantLanding = Landing.where(:id_team=>@id_team, :id_event=>@id_task, :task_member=>@task_member, :status=>'p').order('created_at')
       if @queuePosition == 1 and not(@relevantLanding[0].emailSent)
-        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink)
+        UserMailer.send_first_in_queue(@email, @task_member, @task_name, @flash_team_name, @wait_time, @removalURL, @task_duration, @project_overview, @task_description, @inputs, @input_link, @outputs, @output_description, @invitationLink).deliver
         @relevantLanding[0].emailSent = true
         @relevantLanding[0].emailSentTime = Time.now
         @relevantLanding[0].save

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -75,6 +75,7 @@ class MembersController < ApplicationController
     emails1 = Landing.where(:id_team=>id, :uniq=>uniq, :status=>'s')
     if emails1.empty? 
       member.email_confirmed = true
+      member.confirmationTime = Time.now
       member.save
     else
       if first.email != email
@@ -82,6 +83,7 @@ class MembersController < ApplicationController
         return
       else
         member.email_confirmed = true
+        member.confirmationTime = Time.now
         member.save
       end
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -105,6 +105,22 @@ class UserMailer < ActionMailer::Base
   	mail(:from => sender_email, :bcc => recipient_email, :subject => subject)
   end
 
+def send_first_in_queue(email, task_member, task_name, flash_team_name, wait_time, removalURL, task_duration, project_overview, task_description, inputs, input_link, outputs, output_description, invitationLink)
+@task_member = task_member
+@task_name = task_name
+@flash_team_name = flash_team_name
+@wait_time = wait_time
+@removalURL = removalURL
+@task_duration = task_duration
+@project_overview = project_overview
+@task_description = task_description
+@inputs = inputs
+@outputs = outputs
+@input_link = input_link
+@output_description = output_description
+@invitationLink = invitationLink
+mail(:to => email, :subject => task_member + ' role for the ' + task_name + ' task now available')
+  end
 
   
 end

--- a/app/views/landings/_task_waiting_email_content_landing.html.erb
+++ b/app/views/landings/_task_waiting_email_content_landing.html.erb
@@ -16,7 +16,7 @@
   	<div class="row-fluid">
   		<div class="form-panel form-panel-instructions span12">
   			<p>
-  				<em>Please do not close this page; </em> this page will automatically refresh every 60 seconds with the updated status. In the meanwhile, we recommend that you read the following task description carefully. If you are selected for hiring, you will have 10 minutes from the time you receive that notification to complete the entire registration process. Further, if at any time you would like to opt out of this hiring process  and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. Good luck!
+  				<em>Please do not close this page; </em> this page will automatically refresh every 60 seconds with the updated status. For your convenience, a time-sensitive email will also be sent to you if you are first in the hiring queue. In the meanwhile, we recommend that you read the following task description carefully. If you are selected for hiring, you will have 10 minutes from the time you receive that notification to complete the entire registration process. Further, if at any time you would like to opt out of this hiring process  and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. Good luck!
   			</p>
   		</div>
   	</div>
@@ -33,7 +33,7 @@
 				
 				<div class="row-fluid span11">
 					<!-- <p>
-						Congratulations!  You are at No. <%=@queuePosition%> position in the hiring queue for the <%=@task_member%> role to work on the <%=@task_name%> task as part of the <%=@flash_team_name%> project. Your expected wait time (for the final decision) is <%=@wait_time%>. Please do not close this page; this page will automatically refresh every 60 seconds with the updated status. In the meanwhile, we recommend that you read the following task description carefully. If you are selected for hiring, you will have 10 minutes from the time you receive that notification to complete the entire registration process. Further, if at any time you would like to opt out of this hiring process, we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. Good luck!
+						Congratulations!  You are at No. <%=@queuePosition%> position in the hiring queue for the <%=@task_member%> role to work on the <%=@task_name%> task as part of the <%=@flash_team_name%> project. Your expected wait time (for the final decision) is <%=@wait_time%>. Please do not close this page; this page will automatically refresh every 60 seconds with the updated status. For your convenience, a time-sensitive email will also be sent to you if you are first in the hiring queue. In the meanwhile, we recommend that you read the following task description carefully. If you are selected for hiring, you will have 10 minutes from the time you receive that notification to complete the entire registration process. Further, if at any time you would like to opt out of this hiring process, we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. Good luck!
 					</p> -->
 
 						<p> 

--- a/app/views/user_mailer/_first_in_queue.html.erb
+++ b/app/views/user_mailer/_first_in_queue.html.erb
@@ -15,10 +15,10 @@
   	<div class="row-fluid">
   		<div class="form-panel form-panel-instructions span12">
   			<p>
-  				<em>Please read the following information carefully.</em> You should complete the entire registration process (including confirming your email account) within the next <%=@wait_time%> to retain your position in the hiring queue. However, to reinforce again, you must read the following information very carefully-the originally allocated 10 minutes is a lot of time. 
+  				<em>Please read the following information carefully.</em> You should complete the entire registration process (including confirming your email account) within the next <%=@wait_time%> from the receipt of this email to retain your position in the hiring queue. However, to reinforce again, you must read the following information very carefully-the originally allocated 10 minutes is a lot of time. 
 
 						<br /><br />
-						<em>Please do not close this page;</em> this page will refresh every 60 seconds with the remaining time to help you pace yourself. Moreover, if at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. 
+						If at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. 
   			</p>
   		</div>
   	</div>
@@ -40,10 +40,10 @@
 
 						<br /><br />
 
-						<em>Please read the following information carefully.</em> You should complete the entire registration process (including confirming your email account) within the next <%=@wait_time%> to retain your position in the hiring queue. However, to reinforce again, you must read the following information very carefully-the originally allocated 10 minutes is a lot of time. 
+						<em>Please read the following information carefully.</em> You should complete the entire registration process (including confirming your email account) within the next <%=@wait_time%> from the receipt of this email to retain your position in the hiring queue. However, to reinforce again, you must read the following information very carefully-the originally allocated 10 minutes is a lot of time. 
 
 						<br /><br />
-						<em>Please do not close this page;</em> this page will refresh every 60 seconds with the remaining time to help you pace yourself. If at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. 
+						If at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>.  
 
 					</p> -->
 

--- a/app/views/user_mailer/send_first_in_queue.html.erb
+++ b/app/views/user_mailer/send_first_in_queue.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "first_in_queue", layout: "send_task_hiring_email" %>

--- a/db/migrate/20150404042543_add_email_sent_time.rb
+++ b/db/migrate/20150404042543_add_email_sent_time.rb
@@ -1,0 +1,15 @@
+class AddEmailSentTime < ActiveRecord::Migration
+def change
+add_column :landings, :emailSent, :boolean
+add_column :landings, :emailSentTime, :datetime
+add_column :members, :confirmationTime, :datetime
+Landing.reset_column_information
+Landing.all.each do |landing|
+landing.update_attributes!(:emailSent => false)
+end
+Member.reset_column_information
+Member.all.each do |member|
+member.update_attributes!(:confirmationTime => Time.now)
+end
+end
+end


### PR DESCRIPTION
This implementation supports the following features. 

1. An email is sent out when the person is first in the queue. 
2. Data related to hiring is logged. More specifically, we log the time the "task available" email was sent, the time that the recipient/worker clicked on the “I accept” link in the email, the time that the confirmation email is sent, and the time they accepted the task/joined the team (for worker’s that are number 1 in the queue)

Todo items

1. I had some difficulty logging the body of the email. In any case, we keep track of all the parameters, and so I'm not sure if we really require it. Thoughts?
2. Currently, we do not send out an email to the requester. Although I have an idea for implementing this, I'll have to change a lot of my code and the table schema. Daniela mentioned this to be "low priority", so should we put it off for now?

Testing

Please migrate before testing. The most recent code is up on Heroku. 

1. An email should be sent out to the first person in the hiring queue. 
2. This feature should not affect the existing functionality, i.e. the "remove" and other features should work correctly.
