### PR TITLE
task buttons in modal footer only appear to task members, PCs, clients and authors

### DIFF
--- a/app/assets/javascripts/authoring/members.js
+++ b/app/assets/javascripts/authoring/members.js
@@ -794,6 +794,29 @@ function searchById (arr, id) {
     }
 };
 
+// returns true or false depending on if the current member assigned to task with the groupNum passed in
+function currentMemberTask(groupNum){
+     if(current_user == undefined) {return;}
+
+    var task_id = getEventJSONIndex(groupNum);
+    var eventObj = flashTeamsJSON["events"][task_id];
+
+    var members = eventObj["members"];
+
+    if(members.length == 0){
+        //console.log("no members");
+        return false;
+    }
+
+    for (var i=0; i<members.length; i++) {
+        var member_id = members[i];
+        if (current_user.id == member_id){
+           //console.log("members = true");
+           return true;
+        }
+    }
+}
+
 $(document).ready(function() {
     pressEnterKeyToSubmit("#addMemberInput", "#addMemberButton");
 });

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -1,3 +1,4 @@
+
 function showTaskOverview(groupNum){
 	var task_id = getEventJSONIndex(groupNum);
 	var eventObj = flashTeamsJSON["events"][task_id];
@@ -17,10 +18,10 @@ function showTaskOverview(groupNum){
 	//$('#taskOverview').html(taskOverviewContent);
 	$('#task-text').html(taskOverviewContent);
     
-	if(in_progress == true){
+    // determines which buttons to show in the footer of the modal (e.g., start, complete, etc.) 
+    //checks if team has been started and if the current user is assigned to the task or if the user is an author, PC or client
+	if(in_progress == true && (currentMemberTask(groupNum) == true || uniq_u == "" || memberType == "pc" || memberType == "client")){
         
-
-
 	
 	if(eventObj.status == "started" || eventObj.status == "delayed"){
 	            $("#start-end-task").addClass('btn-success');


### PR DESCRIPTION
start/complete/pause buttons now only show to members assigned to the task as well as PCs, clients and authors

Addresses #184 

This PR updates the task modals so that the start/complete/pause buttons only show to members assigned to the task as well as to all PCs, clients and authors. 

When testing: 
1) create a team, add events and assign members. Also add members to the team and assign them the role of "PC" and/or "client" 
2) It probably makes sense to assign multiple members to a task and make sure things still work properly
3) Start the team and open the team as a member, PC and client. Make sure to open the team as a couple of different members (assigned to different tasks). 

Make sure that the footer buttons show up correctly depending on the role. All clients and PCs (regardless of whether they are assigned to a task) should be able to see the footer buttons. Only members assigned a specific task, however, should be able to see the footer buttons. The author should always see all the buttons. 
