### PR TITLE
Dr role updates

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -298,11 +298,12 @@ function renderEverything(firstTime) {
         window.entryManager = new window.EntryManager(flashTeamsJSON);
 
         setCurrentMember();
+        renderProjectOverview();
         
         if(firstTime) {
             //setCurrentMember(); //commented this out because we now always call setCurrentMember() in case changes are made during project
             initializeTimelineDuration();
-            renderProjectOverview(); //note: not sure if this goes here, depends on who sees the project overview (e.g., user and/or requester)
+            //renderProjectOverview(); //commented this out because we now always call setCurrentMember() in case changes are made during project
         }
 
 
@@ -519,6 +520,12 @@ var flashTeamUpdated = function(){
     var updated_gdrive = loadedStatus.flash_teams_json["folder"];
     var updated_local_update = loadedStatus.local_update;
     var updated_members = loadedStatus.flash_teams_json['members'];
+    var updated_project_overview = loadedStatus.flash_teams_json['projectoverview'];
+
+    if(flashTeamsJSON['projectoverview'] != updated_project_overview){
+        console.log('project overview has been updated');
+        return true;
+    }
 
     if(JSON.stringify(flashTeamsJSON['members'])!= JSON.stringify(updated_members)){
         return true;

--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -292,9 +292,14 @@ function renderEverything(firstTime) {
 
         in_progress = loadedStatus.flash_team_in_progress;
         flashTeamsJSON = loadedStatus.flash_teams_json;
+
         
         // initialize the entry manager after flashTeamsJSON has been loaded
         window.entryManager = new window.EntryManager(flashTeamsJSON);
+
+        //console.log('current_user before: ' + JSON.stringify(current_user));
+        setCurrentMember();
+        //console.log('current_user after: ' + JSON.stringify(current_user));
         
         if(firstTime) {
             setCurrentMember();
@@ -515,6 +520,11 @@ var flashTeamUpdated = function(){
     var updated_task_groups = loadedStatus.task_groups;
     var updated_gdrive = loadedStatus.flash_teams_json["folder"];
     var updated_local_update = loadedStatus.local_update;
+    var updated_members = loadedStatus.flash_teams_json['members'];
+
+    if(JSON.stringify(flashTeamsJSON['members'])!= JSON.stringify(updated_members)){
+        return true;
+    }
 
     // if certain task attributes (e.g., documentation answers, members added, etc.)
     if(updated_local_update > flashTeamsJSON['local_update']){

--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -297,12 +297,10 @@ function renderEverything(firstTime) {
         // initialize the entry manager after flashTeamsJSON has been loaded
         window.entryManager = new window.EntryManager(flashTeamsJSON);
 
-        //console.log('current_user before: ' + JSON.stringify(current_user));
         setCurrentMember();
-        //console.log('current_user after: ' + JSON.stringify(current_user));
         
         if(firstTime) {
-            setCurrentMember();
+            //setCurrentMember(); //commented this out because we now always call setCurrentMember() in case changes are made during project
             initializeTimelineDuration();
             renderProjectOverview(); //note: not sure if this goes here, depends on who sees the project overview (e.g., user and/or requester)
         }

--- a/app/assets/javascripts/authoring/members.js
+++ b/app/assets/javascripts/authoring/members.js
@@ -72,7 +72,8 @@ function setCurrentMember() {
             current_user = member;
             isUser = true;
             memberType = member.type;
-            $('#member_role_span').html(current_user.role);
+            
+            $('#member_role_span').html(current_user.role); //updates the "Your Role: " text in left sidebar
 
             if (member.type == "worker" && $('#member-container').css('display') != "none"){
                 //console.log('member switched to worker role');
@@ -81,8 +82,6 @@ function setCurrentMember() {
             if (member.type == "pc" && $('#member-container').css('display') == "none"){
                 //console.log('member switched to pc role');
                 $('#member-container').css('display', 'block');
-                //$('#member-container').attr("style", "display:none;");
-                //console.log("member role changed");
             }
         }
         

--- a/app/assets/javascripts/authoring/members.js
+++ b/app/assets/javascripts/authoring/members.js
@@ -73,6 +73,17 @@ function setCurrentMember() {
             isUser = true;
             memberType = member.type;
             $('#member_role_span').html(current_user.role);
+
+            if (member.type == "worker" && $('#member-container').css('display') != "none"){
+                //console.log('member switched to worker role');
+                $('#member-container').css('display', 'none');
+            }
+            if (member.type == "pc" && $('#member-container').css('display') == "none"){
+                //console.log('member switched to pc role');
+                $('#member-container').css('display', 'block');
+                //$('#member-container').attr("style", "display:none;");
+                //console.log("member role changed");
+            }
         }
         
     } else {

--- a/app/assets/javascripts/authoring/members.js
+++ b/app/assets/javascripts/authoring/members.js
@@ -72,6 +72,7 @@ function setCurrentMember() {
             current_user = member;
             isUser = true;
             memberType = member.type;
+            $('#member_role_span').html(current_user.role);
         }
         
     } else {
@@ -79,6 +80,7 @@ function setCurrentMember() {
         isUser = false;
         memberType = "author";
     }
+
 };
 
 var folderClickFn = function(e) {

--- a/app/assets/javascripts/authoring/sidebar.js
+++ b/app/assets/javascripts/authoring/sidebar.js
@@ -89,7 +89,7 @@ function saveProjectOverview(){
 	 
     flashTeamsJSON["projectoverview"] = project_overview_input;
     
-    console.log("saved projectoverview: " + flashTeamsJSON["projectoverview"]);
+    //console.log("saved projectoverview: " + flashTeamsJSON["projectoverview"]);
     
     updateStatus();
     

--- a/app/views/flash_teams/_left_sidebar.html.erb
+++ b/app/views/flash_teams/_left_sidebar.html.erb
@@ -64,12 +64,16 @@
       </div>
 
       <% if @member_type == "pc" || @member_type == "client" %>
-      <div id="member-container" class="well" style="overflow-y:scroll;">
+        <div id="member-container" class="sidebar-item" style="overflow-y:scroll;">
+      <% else %>
+        <!--Need to include the div for worker (e.g., display none) because we display it via javascript if member role changes -->
+        <div id="member-container" class="sidebar-item" style="overflow-y:scroll; display: none;">
+      <% end %>
         <!-- Render member roles container --> 
         <%= render :partial => "roles" %> 
       </div>
     
-      <% end %>
+      
     
     <% end %>
   </div>

--- a/app/views/flash_teams/_left_sidebar.html.erb
+++ b/app/views/flash_teams/_left_sidebar.html.erb
@@ -47,7 +47,7 @@
     <% if in_expert_view %>
       <div class="welcome">
         <h4><b>Welcome <%= @user_name %>!</b>
-        <br /> Your role: <%= @member_role %></h4>
+        <br /> Your role: <span id="member_role_span"><%= @member_role %></span></h4>
       </div>
     
       <div id="project-status-container" class="sidebar-item active">


### PR DESCRIPTION
The member role information should update in all views when changed. 

1) Previously, if the role (e.g., role name) was changed in author view, the worker would need to refresh the page in order to see the change in the left sidebar where it says "Welcome, WORKER NAME" followed by "Your Role Is: ROLE NAME" [the ROLE NAME is what should change] 

2) All role information should update on the event blocks when changed in author or edit mode (e.g., the role name, color, etc. on the events should update in realtime) 

3) If you change the "type" of a member from either worker to PC or from PC to worker, the roles widget on the left sidebar should appear and disappear in realtime, respectively. Previously, if you would change a member's role, the role widget would stay on the page or not appear until the member refreshed the page. PCs should be able to see the role widget whereas workers shouldn't be able to

4) Fixed the issue causing the team roles to look weird in the sidebar in PC view (e.g., resolved issue #293)

5) Project overview now updates correctly in realtime (previously it would only update on refresh)

When testing: 
1) Create a new team 
2) Add a member or two and access the timeline in both views (e.g., you should have author and worker view)
3) Add events 
4) Make changes to the members (e.g., change their name, color, type) and make sure that the changes all update in the other views correctly and that there are no errors in the console 
5) Start the team 
6) Make changes to the members similar to those described in item 4 above. Note that right now the team doesn't need to be in edit mode for authors or PCs to make changes to the member/role info. In the future, we might consider making the role info "read only" when team is in progress unless it is in edit mode but for now it is fine
7) Try changing the project overview in author view and make sure it updates correctly in realtime in the worker view

