### PR TITLE
Dr collab modals

### DIFF
--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -395,7 +395,7 @@ function getTaskOverviewContent(groupNum){
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
                 content += '<p style="padding-top: 5px">';
                 if(input_ev['outputs'].length ==0){
-                    content+= '<b>collaboration</b>';
+                    content+= '<b>prior task results</b>';
                 
                 }else{
                     content +='<b><a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></b>';

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -10,6 +10,7 @@ function showTaskOverview(groupNum){
 	
 	//modal label
 	var label = title;
+
 	$('#task_modal_Label').html(label);
 
     $("#modal-close-btn").attr('onclick', 'logHideTaskOverview('+groupNum+')');
@@ -96,6 +97,44 @@ function showTaskOverview(groupNum){
 function logHideTaskOverview(groupNum){
     logActivity("logHideTaskOverview(groupNum)",'Hide Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
 }
+
+function showShortTaskOverview(groupNum){
+        var task_id = getEventJSONIndex(groupNum);
+        var eventObj = flashTeamsJSON["events"][task_id];
+        var title = eventObj["title"];
+    
+        //modal label
+        var label = title;
+        var taskOverviewContent = getTaskOverviewContent(groupNum);
+
+        $('#task_modal_Label2').html(label);
+        $("#modal-close-btn2").attr('onclick', 'logHideShortTaskOverview('+groupNum+')');
+
+        //$("#modal-close-btn2").attr('onclick', 'logHideTaskOverview('+groupNum+')');
+
+        $('#task-text2').html(taskOverviewContent);
+
+        var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" style="float: right" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Go to Deliverables Folder</a>'
+                            + '<button class="btn" data-dismiss="modal" aria-hidden="true" style="float: left" onclick="logHideShortTaskOverview(' + groupNum  + ')">Close</button>';
+
+        $('#task_modal2').modal('show'); 
+       $('.task-modal-footer2').html(modal_footer);
+       //$('.task-modal-body2').html(modal_body);
+
+        logActivity("showShortTaskOverview(groupNum)",'Show Short Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
+
+    
+}
+
+function logShortTaskOverviewGDriveBtnClick(groupNum){
+        logActivity("logShortTaskOverviewGDriveBtnClick(groupNum)",'Clicked on gDrive Button on Short Task Overview Modal', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
+}
+
+//logs when the user clicks the x on the top right of the task modal to hide it
+function logHideShortTaskOverview(groupNum){
+    logActivity("logHideShortTaskOverview(groupNum)",'Hide Short Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
+}
+
 
 
 function editTaskOverview(popover,groupNum){
@@ -386,7 +425,12 @@ function getTaskOverviewContent(groupNum){
         for(var i=0; i<handoff_inputs.length; i++){
                 input_ev_id = handoff_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
+                //content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
+                if(input_ev['outputs'].length !=0){
+                    content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
+                }
+                content += '</p>';
         }
 
         content +=  '</div>'; 
@@ -431,7 +475,11 @@ function getTaskOverviewContent(groupNum){
         for(var i=0; i<collab_inputs.length; i++){
                 input_ev_id = collab_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
+                if(input_ev['outputs'].length !=0){
+                    content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
+                }
+                content += '</p>';
         }
 
         content +=  '</div>'; 
@@ -854,4 +902,32 @@ function getHandoffInputs(groupNum){
     }
 
     return handoff_inputs;
+}
+
+// resolves jquery stacking error in console
+//http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
+$.fn.modal.Constructor.prototype.enforceFocus = function () {};
+
+//improves apperance of stacked task modals
+//http://gurde.com/stacked-bootstrap-modals/
+$(document)  
+  .on('show.bs.modal', '.modal', function(event) {
+    $(this).appendTo($('body'));
+  })
+  .on('shown.bs.modal', '.modal.in', function(event) {
+    setModalsAndBackdropsOrder();
+  })
+  .on('hidden.bs.modal', '.modal', function(event) {
+    setModalsAndBackdropsOrder();
+  });
+
+function setModalsAndBackdropsOrder() {  
+  var modalZIndex = 1040;
+  $('.modal.in').each(function(index) {
+    var $modal = $(this);
+    modalZIndex++;
+    $modal.css('zIndex', modalZIndex);
+    $modal.next('.modal-backdrop.in').addClass('hidden').css('zIndex', modalZIndex - 1);
+});
+  $('.modal.in:visible:last').focus().next('.modal-backdrop.in').removeClass('hidden');
 }

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -418,6 +418,26 @@ function getTaskOverviewContent(groupNum){
     // }
 
     // HANDOFF OPTION 3: 
+    // var handoff_inputs = events_immediately_before(groupNum);
+
+    // if(handoff_inputs.length!=0) {
+    //     content += '<div class="row-fluid" >';  
+    //     content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
+    //     for(var i=0; i<handoff_inputs.length; i++){
+    //             input_ev_id = handoff_inputs[i];
+    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+    //             //content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
+    //             content += '<p style="padding-top: 5px"><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>';
+    //             if(input_ev['outputs'].length !=0){
+    //                 content +='<br /><b><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</b>';
+    //             }
+    //             content += '</p>';
+    //     }
+
+    //     content +=  '</div>'; 
+    // }
+
+    // HANDOFF OPTION 4: 
     var handoff_inputs = events_immediately_before(groupNum);
 
     if(handoff_inputs.length!=0) {
@@ -426,11 +446,16 @@ function getTaskOverviewContent(groupNum){
         for(var i=0; i<handoff_inputs.length; i++){
                 input_ev_id = handoff_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                //content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
-                content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
-                if(input_ev['outputs'].length !=0){
-                    content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
+                content += '<p style="padding-top: 5px">';
+                if(input_ev['outputs'].length ==0){
+                    content+= '<b>collaboration</b>';
+                
+                }else{
+                    content +='<b><a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></b>';
+
                 }
+
+                content += '<br /><span style="padding-left: 25px"><em>from: <a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></em></span>';
                 content += '</p>';
         }
 
@@ -468,6 +493,25 @@ function getTaskOverviewContent(groupNum){
     // }
 
     //COLLAB OPTION 3:
+    //  var collab_inputs = events_in_collaboration(groupNum);
+
+    // if(collab_inputs.length!=0) {
+    //     content += '<div class="row-fluid" >';  
+    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
+    //     for(var i=0; i<collab_inputs.length; i++){
+    //             input_ev_id = collab_inputs[i];
+    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+    //             content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
+    //             if(input_ev['outputs'].length !=0){
+    //                 content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logCollabInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
+    //             }
+    //             content += '</p>';
+    //     }
+
+    //     content +=  '</div>'; 
+    // }
+
+    //COLLAB OPTION 4:
      var collab_inputs = events_in_collaboration(groupNum);
 
     if(collab_inputs.length!=0) {
@@ -476,10 +520,17 @@ function getTaskOverviewContent(groupNum){
         for(var i=0; i<collab_inputs.length; i++){
                 input_ev_id = collab_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
-                if(input_ev['outputs'].length !=0){
-                    content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
+                content += '<p style="padding-top: 5px">';
+                if(input_ev['outputs'].length ==0){
+                    content+= '<b>collaboration</b>';
+                
+                }else{
+                    content +='<b><a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logCollabInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></b>';
+
                 }
+
+                content += '<br /><span style="padding-left: 25px"><em>with: <a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></em></span>';
+
                 content += '</p>';
         }
 

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -114,7 +114,7 @@ function showShortTaskOverview(groupNum){
 
         $('#task-text2').html(taskOverviewContent);
 
-        var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" style="float: right" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Go to Deliverables Folder</a>'
+        var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: right" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Go to Deliverables Folder</a>'
                             + '<button class="btn" data-dismiss="modal" aria-hidden="true" style="float: left" onclick="logHideShortTaskOverview(' + groupNum  + ')">Close</button>';
 
         $('.task-modal-footer2').html(modal_footer);

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -15,7 +15,6 @@ function showTaskOverview(groupNum){
     $("#modal-close-btn").attr('onclick', 'logHideTaskOverview('+groupNum+')');
 
 	//modal content
-	//var taskOverviewContent = '<div id="task-description-text"><p>' + description + '</p></div>';	
 	var taskOverviewContent = getTaskOverviewContent(groupNum);
 	//$('#taskOverview').html(taskOverviewContent);
 	$('#task-text').html(taskOverviewContent);
@@ -347,31 +346,92 @@ function getTaskOverviewContent(groupNum){
     content += '</div>';
     
     
-	//var events_before_ids = events_immediately_before(groupNum);
-	
-    var handoff_inputs = getHandoffInputs(groupNum);
+
+  // HANDOFF OPTION 1: 
+  //   var handoff_inputs = getHandoffInputs(groupNum);
+
+  //   if(handoff_inputs.length!=0) {
+  //       content += '<div class="row-fluid" >';  
+		// content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
+		// for(var i=0; i<handoff_inputs.length; i++){
+  //               input_ev_id = handoff_inputs[i][0];
+  //               var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+  //               content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ handoff_inputs[i][1] +'</a></br>';
+  //       }
+
+  //       content +=  '</div>'; 
+  //   }
+
+    // HANDOFF OPTION 2:
+    // var handoff_inputs = events_immediately_before(groupNum);
+
+    // if(handoff_inputs.length!=0) {
+    //     content += '<div class="row-fluid" >';  
+    //     content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
+    //     for(var i=0; i<handoff_inputs.length; i++){
+    //             input_ev_id = handoff_inputs[i];
+    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></br>';
+    //     }
+
+    //     content +=  '</div>'; 
+    // }
+
+    // HANDOFF OPTION 3: 
+    var handoff_inputs = events_immediately_before(groupNum);
 
     if(handoff_inputs.length!=0) {
         content += '<div class="row-fluid" >';  
-		content += '<hr /><h5>Review the following deliverables: </h5>';
-		for(var i=0; i<handoff_inputs.length; i++){
-                input_ev_id = handoff_inputs[i][0];
+        content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
+        for(var i=0; i<handoff_inputs.length; i++){
+                input_ev_id = handoff_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ handoff_inputs[i][1] +'</a></br>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
         }
 
         content +=  '</div>'; 
     }
 
-    var collab_inputs = getCollabInputs(groupNum);
+    //COLLAB OPTION 1:
+    // var collab_inputs = getCollabInputs(groupNum);
+
+    // if(collab_inputs.length!=0) {
+    //     content += '<div class="row-fluid" >';  
+    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
+    //     for(var i=0; i<collab_inputs.length; i++){
+    //             input_ev_id = collab_inputs[i][0];
+    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ collab_inputs[i][1] +'</a></br>';
+    //     }
+
+    //     content +=  '</div>'; 
+    // }
+
+    //COLLAB OPTION 2:
+    // var collab_inputs = events_in_collaboration(groupNum);
+
+    // if(collab_inputs.length!=0) {
+    //     content += '<div class="row-fluid" >';  
+    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
+    //     for(var i=0; i<collab_inputs.length; i++){
+    //             input_ev_id = collab_inputs[i];
+    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></br>';
+    //     }
+
+    //     content +=  '</div>'; 
+    // }
+
+    //COLLAB OPTION 3:
+     var collab_inputs = events_in_collaboration(groupNum);
 
     if(collab_inputs.length!=0) {
         content += '<div class="row-fluid" >';  
         content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
         for(var i=0; i<collab_inputs.length; i++){
-                input_ev_id = collab_inputs[i][0];
+                input_ev_id = collab_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '[' + input_ev.title + '] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ collab_inputs[i][1] +'</a></br>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
         }
 
         content +=  '</div>'; 

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -384,60 +384,7 @@ function getTaskOverviewContent(groupNum){
 		}
     			
     content += '</div>';
-    
-    
 
-  // HANDOFF OPTION 1: 
-  //   var handoff_inputs = getHandoffInputs(groupNum);
-
-  //   if(handoff_inputs.length!=0) {
-  //       content += '<div class="row-fluid" >';  
-		// content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
-		// for(var i=0; i<handoff_inputs.length; i++){
-  //               input_ev_id = handoff_inputs[i][0];
-  //               var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-  //               content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ handoff_inputs[i][1] +'</a></br>';
-  //       }
-
-  //       content +=  '</div>'; 
-  //   }
-
-    // HANDOFF OPTION 2:
-    // var handoff_inputs = events_immediately_before(groupNum);
-
-    // if(handoff_inputs.length!=0) {
-    //     content += '<div class="row-fluid" >';  
-    //     content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
-    //     for(var i=0; i<handoff_inputs.length; i++){
-    //             input_ev_id = handoff_inputs[i];
-    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></br>';
-    //     }
-
-    //     content +=  '</div>'; 
-    // }
-
-    // HANDOFF OPTION 3: 
-    // var handoff_inputs = events_immediately_before(groupNum);
-
-    // if(handoff_inputs.length!=0) {
-    //     content += '<div class="row-fluid" >';  
-    //     content += '<hr /><h5>Review the following tasks and deliverables, which are important for your task: </h5>';
-    //     for(var i=0; i<handoff_inputs.length; i++){
-    //             input_ev_id = handoff_inputs[i];
-    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-    //             //content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
-    //             content += '<p style="padding-top: 5px"><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>';
-    //             if(input_ev['outputs'].length !=0){
-    //                 content +='<br /><b><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</b>';
-    //             }
-    //             content += '</p>';
-    //     }
-
-    //     content +=  '</div>'; 
-    // }
-
-    // HANDOFF OPTION 4: 
     var handoff_inputs = events_immediately_before(groupNum);
 
     if(handoff_inputs.length!=0) {
@@ -462,56 +409,6 @@ function getTaskOverviewContent(groupNum){
         content +=  '</div>'; 
     }
 
-    //COLLAB OPTION 1:
-    // var collab_inputs = getCollabInputs(groupNum);
-
-    // if(collab_inputs.length!=0) {
-    //     content += '<div class="row-fluid" >';  
-    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
-    //     for(var i=0; i<collab_inputs.length; i++){
-    //             input_ev_id = collab_inputs[i][0];
-    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ collab_inputs[i][1] +'</a></br>';
-    //     }
-
-    //     content +=  '</div>'; 
-    // }
-
-    //COLLAB OPTION 2:
-    // var collab_inputs = events_in_collaboration(groupNum);
-
-    // if(collab_inputs.length!=0) {
-    //     content += '<div class="row-fluid" >';  
-    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
-    //     for(var i=0; i<collab_inputs.length; i++){
-    //             input_ev_id = collab_inputs[i];
-    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-    //             content += '[<a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a>] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a></br>';
-    //     }
-
-    //     content +=  '</div>'; 
-    // }
-
-    //COLLAB OPTION 3:
-    //  var collab_inputs = events_in_collaboration(groupNum);
-
-    // if(collab_inputs.length!=0) {
-    //     content += '<div class="row-fluid" >';  
-    //     content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
-    //     for(var i=0; i<collab_inputs.length; i++){
-    //             input_ev_id = collab_inputs[i];
-    //             var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-    //             content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
-    //             if(input_ev['outputs'].length !=0){
-    //                 content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logCollabInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
-    //             }
-    //             content += '</p>';
-    //     }
-
-    //     content +=  '</div>'; 
-    // }
-
-    //COLLAB OPTION 4:
      var collab_inputs = events_in_collaboration(groupNum);
 
     if(collab_inputs.length!=0) {

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -121,11 +121,29 @@ function editTaskOverview(popover,groupNum){
 		$("#edit-save-task").html('Save');	
 
         // create the read only tags for inputs created by handoffs or collaborations
-        var int_inputs_tags = $('#int_inputs').tags({
+        // var int_inputs_tags = $('#int_inputs').tags({
+        //     bootstrapVersion: "2",
+        //     readOnly: true,
+        //     readOnlyEmptyMessage: "No handoff or collaboration inputs from other tasks exist.",
+        //     tagData: get_int_inputs_array(groupNum),
+        //     tagClass: "btn-info",
+        //     tagSize: "sm",
+        // });
+
+        var handoff_inputs_tags = $('#handoff_inputs').tags({
             bootstrapVersion: "2",
             readOnly: true,
-            readOnlyEmptyMessage: "No handoff or collaboration inputs from other tasks exist.",
-            tagData: get_int_inputs_array(groupNum),
+            readOnlyEmptyMessage: "No handoff inputs from other tasks exist.",
+            tagData: get_int_inputs_array(groupNum, "handoff"),
+            tagClass: "btn-info",
+            tagSize: "sm",
+        });
+
+        var collab_inputs_tags = $('#collab_inputs').tags({
+            bootstrapVersion: "2",
+            readOnly: true,
+            readOnlyEmptyMessage: "No collaboration inputs from other tasks exist.",
+            tagData: get_int_inputs_array(groupNum, "collab"),
             tagClass: "btn-info",
             tagSize: "sm",
         });
@@ -226,8 +244,9 @@ function getTaskOverviewForm(groupNum){
         +'<br />'
         + '<div><b>Description </br></b><textarea class="span12" style="width:475px" rows="5" placeholder="Description of the task..." id="notes">' + notes + '</textarea></div>'
         //+'<br />'
-        + '<div style="margin-bottom: 5px;"><b>Inputs From Handoffs or Collaborations</b><br> <div id="int_inputs"></div><br /></div>'
-        + '<div><br /><b>Additional Inputs</b><br> <div><input type="text" value="' + inputs + '" placeholder="Add input" id="inputs" /></div>'
+        + '<div style="margin-bottom: 15px;"><b>Inputs From Handoffs</b><br> <div id="handoff_inputs"></div><br /></div>'
+        + '<div style="margin-bottom: 15px;"><b>Inputs From Collaborations</b><br> <div id="collab_inputs"></div><br /></div>'
+        + '<div><b>Additional Inputs</b><br> <div><input type="text" value="' + inputs + '" placeholder="Add input" id="inputs" /></div>'
         + '<div><b>Deliverables</b> <div><input type="text" value="' + outputs + '" placeholder="Add deliverable" id="outputs" /></div>'
         + '<div><b>Task Documentation Questions </b><i>(Start a new line to create a new question)</i></br><textarea class="span12" style="width:475px" rows="5" placeholder="Add any General Questions here" id="questions">' + questions + '</textarea></div>'
         + '<div id="outputQForm">';
@@ -287,6 +306,11 @@ function getTaskOverviewContent(groupNum){
                 }
 
         content += '</div>';
+
+        content += '<hr/><div class="row-fluid"><em>30 minutes of this task are allocated for reading the requirements'
+        +' and reviewing the previous materials. Click the start button when you are ready to review.</em>';
+        
+    content += '</div>';
 	
 		content += '<hr /><div class="row-fluid">';
 		
@@ -302,16 +326,13 @@ function getTaskOverviewContent(groupNum){
 		content += '</div>';
 		
         //content += '</div>';
-        content += '<hr/><div class="row-fluid"><em>30 minutes of this task are allocated for reading the requirements'
-        +' and reviewing the previous materials. Click start when you are ready to review.</em>';
-		
-	content += '</div>';
+        
 		
 	content += '<div class="row-fluid" >';
 		
 		if(ev.outputs) {
 			//content += '<b>Deliverables:</b><br>';
-			content +=  '<br /><h5>Specifically, you are expected to produce the following deliverables: </h5>';
+			content +=  '<hr /><h5>Specifically, you are expected to produce the following deliverables: </h5>';
 			var outputs = ev.outputs.split(",");
 			for(var i=0;i<outputs.length;i++){
 				
@@ -325,36 +346,37 @@ function getTaskOverviewContent(groupNum){
     			
     content += '</div>';
     
-    content += '<div class="row-fluid" >';	
+    
 	//var events_before_ids = events_immediately_before(groupNum);
 	
-    var all_inputs = getAllInputs(groupNum);
+    var handoff_inputs = getHandoffInputs(groupNum);
 
-    if(all_inputs.length!=0) {
-		content += '<br /><h5>Review the following deliverables: </h5>';
-		for(var i=0; i<all_inputs.length; i++){
-                input_ev_id = all_inputs[i][0];
+    if(handoff_inputs.length!=0) {
+        content += '<div class="row-fluid" >';  
+		content += '<hr /><h5>Review the following deliverables: </h5>';
+		for(var i=0; i<handoff_inputs.length; i++){
+                input_ev_id = handoff_inputs[i][0];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logInputClick(' + groupNum + ',' + input_ev_id + ')">'+ all_inputs[i][1] +'</a></br>';
+                content += '<a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ handoff_inputs[i][1] +'</a></br>';
         }
-        //content += '<b>Inputs:</b><br>';
-		/*var inputs = ev.inputs.split(",");
-		for(var i=0;i<inputs.length;i++){
-			content += "<a href=" + ev["gdrive"][1] + " target='_blank'>"+ inputs[i] +"</a></br>";
-        }
-        //content +="</br>"
 
-        for(var i=0;i<events_before_ids.length;i++){
-           
-            var ev_before = flashTeamsJSON["events"][getEventJSONIndex(events_before_ids[i])];
-            var outputs = ev_before["outputs"].split(",");
-           
-            for(var j=0;j<outputs.length;j++){   
-                content += "<a href=" + ev_before["gdrive"][1] + " target='_blank'>"+ outputs[j] + "</a></br>";
-            }					
-	    } */   
+        content +=  '</div>'; 
     }
-		content +=  '</div>'; 
+
+    var collab_inputs = getCollabInputs(groupNum);
+
+    if(collab_inputs.length!=0) {
+        content += '<div class="row-fluid" >';  
+        content += '<hr /><h5>As you work on your deliverables, you should collaborate with the team members working on the following tasks and deliverables: </h5>';
+        for(var i=0; i<collab_inputs.length; i++){
+                input_ev_id = collab_inputs[i][0];
+                var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
+                content += '[' + input_ev.title + '] <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ collab_inputs[i][1] +'</a></br>';
+        }
+
+        content +=  '</div>'; 
+    }
+		
 		
 		content += "<hr/>";
 		
@@ -457,12 +479,17 @@ function getTaskOverviewContent(groupNum){
 }
 
 
-function logInputClick(groupNum, inputEvId){
+function logHandoffInputClick(groupNum, inputEvId){
     //console.log('Task Modal Event groupNum: ' + groupNum + ' Id of input event clicked on: ' + inputEvId);
-    logActivity("logInputClick(groupNum, inputEvId)",'Clicked on Input Link on Task Modal - Task Modal Event groupNum: ' + groupNum + ' Id of input event clicked on: ' + inputEvId, new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"]);
+    logActivity("logHandoffClick(groupNum, inputEvId)",'Clicked on Input Link on Task Modal - Task Modal Event groupNum: ' + groupNum + ' Id of input event clicked on: ' + inputEvId, new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"]);
 
 }
 
+function logCollabInputClick(groupNum, inputEvId){
+    //console.log('Task Modal Event groupNum: ' + groupNum + ' Id of input event clicked on: ' + inputEvId);
+    logActivity("logHandoffClick(groupNum, inputEvId)",'Clicked on Input Link on Task Modal - Task Modal Event groupNum: ' + groupNum + ' Id of input event clicked on: ' + inputEvId, new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"]);
+
+}
 
 /* Returns a string with the time in the format of h:mm (if h<10) or hh:mm (if h>=10)
 *  Returns a negative time string if the task is delayed
@@ -688,14 +715,21 @@ function getAllInputs(groupNum){
 
 
 //this function returns all of a task's inputs that are only from interactions (e.g., not inputs added manually to a task)
-function get_int_inputs_array(groupNum){
+function get_int_inputs_array(groupNum, type){
     //var events = flashTeamsJSON["events"];
     var int_inputs_array=[];
     
     var task_id = getEventJSONIndex(groupNum);
     var eventObj = flashTeamsJSON["events"][task_id];
 
-    var all_inputs_array = getAllInputs(groupNum);
+    //var all_inputs_array = getAllInputs(groupNum);
+
+    if(type == "handoff"){
+        var all_inputs_array = getHandoffInputs(groupNum);
+    }
+    else if(type == "collab"){
+        var all_inputs_array = getCollabInputs(groupNum);
+    }
     
     for( var j=0; j<all_inputs_array.length; j++){
 
@@ -704,4 +738,60 @@ function get_int_inputs_array(groupNum){
         }
     }
     return int_inputs_array;
+}
+
+
+//returns an array of inputs of the task only from collaborations
+// getHandoffInputs returns: [[task_id, input]]
+function getCollabInputs(groupNum){
+   var task_id = getEventJSONIndex(groupNum);
+   var ev = flashTeamsJSON["events"][task_id];
+
+   var collaboration_ids = events_in_collaboration(groupNum);
+   var collab_inputs=[];
+
+
+    if(collaboration_ids.length!=0){
+        for(var i=0;i<collaboration_ids.length;i++){
+           
+            var ev_collab = flashTeamsJSON["events"][getEventJSONIndex(collaboration_ids[i])];
+            if(ev_collab["outputs"] =="" || ev_collab["outputs"] == undefined)
+                continue;
+
+            var outputs = ev_collab["outputs"].split(",");
+            
+            for(var j=0;j<outputs.length;j++){   
+               collab_inputs.push([ev_collab.id , outputs[j] ])
+            }                   
+        }   
+    }
+
+    return collab_inputs;
+}
+
+//returns an array of inputs of the task only from handoffs
+// getHandoffInputs returns: [[task_id, input]]
+function getHandoffInputs(groupNum){
+   var task_id = getEventJSONIndex(groupNum);
+   var ev = flashTeamsJSON["events"][task_id];
+
+   var events_before_ids = events_immediately_before(groupNum);
+   var handoff_inputs=[];
+
+    if(events_before_ids.length!=0){
+        for(var i=0;i<events_before_ids.length;i++){
+           
+            var ev_before = flashTeamsJSON["events"][getEventJSONIndex(events_before_ids[i])];
+            if(ev_before["outputs"] =="" || ev_before["outputs"] == undefined)
+                continue;
+
+            var outputs = ev_before["outputs"].split(",");
+            
+            for(var j=0;j<outputs.length;j++){   
+               handoff_inputs.push([ev_before.id , outputs[j] ])
+            }                   
+        }    
+    }
+
+    return handoff_inputs;
 }

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -371,7 +371,7 @@ function getTaskOverviewContent(groupNum){
 		
 		if(ev.outputs) {
 			//content += '<b>Deliverables:</b><br>';
-			content +=  '<hr /><h5>Specifically, you are expected to produce the following deliverables: </h5>';
+			content +=  '<br /><h5>Specifically, you are expected to produce the following deliverables: </h5>';
 			var outputs = ev.outputs.split(",");
 			for(var i=0;i<outputs.length;i++){
 				

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -117,8 +117,10 @@ function showShortTaskOverview(groupNum){
         var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" style="float: right" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Go to Deliverables Folder</a>'
                             + '<button class="btn" data-dismiss="modal" aria-hidden="true" style="float: left" onclick="logHideShortTaskOverview(' + groupNum  + ')">Close</button>';
 
+        $('.task-modal-footer2').html(modal_footer);
+        
         $('#task_modal2').modal('show'); 
-       $('.task-modal-footer2').html(modal_footer);
+       
        //$('.task-modal-body2').html(modal_body);
 
         logActivity("showShortTaskOverview(groupNum)",'Show Short Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
@@ -426,7 +428,7 @@ function getTaskOverviewContent(groupNum){
                 input_ev_id = handoff_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
                 //content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b><br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]</p>';
-                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
                 if(input_ev['outputs'].length !=0){
                     content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
                 }
@@ -475,7 +477,7 @@ function getTaskOverviewContent(groupNum){
         for(var i=0; i<collab_inputs.length; i++){
                 input_ev_id = collab_inputs[i];
                 var input_ev = flashTeamsJSON["events"][getEventJSONIndex(input_ev_id)];
-                content += '<p style="padding-top: 5px"><b><a onclick=showTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
+                content += '<p style="padding-top: 5px"><b><a onclick=showShortTaskOverview(' + input_ev_id + ')>' + input_ev.title + '</a></b>';
                 if(input_ev['outputs'].length !=0){
                     content +='<br /><em>[Deliverables: </em> <a href=' + input_ev["gdrive"][1] + ' target="_blank" onclick="logHandoffInputClick(' + groupNum + ',' + input_ev_id + ')">'+ input_ev['outputs'].split(',').join(', ') +'</a>]';
                 }

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -120,8 +120,7 @@ function showShortTaskOverview(groupNum){
         $('.task-modal-footer2').html(modal_footer);
         
         $('#task_modal2').modal('show'); 
-       
-       //$('.task-modal-body2').html(modal_body);
+
 
         logActivity("showShortTaskOverview(groupNum)",'Show Short Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
 
@@ -912,24 +911,24 @@ $.fn.modal.Constructor.prototype.enforceFocus = function () {};
 
 //improves apperance of stacked task modals
 //http://gurde.com/stacked-bootstrap-modals/
-$(document)  
-  .on('show.bs.modal', '.modal', function(event) {
-    $(this).appendTo($('body'));
-  })
-  .on('shown.bs.modal', '.modal.in', function(event) {
-    setModalsAndBackdropsOrder();
-  })
-  .on('hidden.bs.modal', '.modal', function(event) {
-    setModalsAndBackdropsOrder();
-  });
+// $(document)  
+//   .on('show.bs.modal', '.modal', function(event) {
+//     $(this).appendTo($('body'));
+//   })
+//   .on('shown.bs.modal', '.modal.in', function(event) {
+//     setModalsAndBackdropsOrder();
+//   })
+//   .on('hidden.bs.modal', '.modal', function(event) {
+//     setModalsAndBackdropsOrder();
+//   });
 
-function setModalsAndBackdropsOrder() {  
-  var modalZIndex = 1040;
-  $('.modal.in').each(function(index) {
-    var $modal = $(this);
-    modalZIndex++;
-    $modal.css('zIndex', modalZIndex);
-    $modal.next('.modal-backdrop.in').addClass('hidden').css('zIndex', modalZIndex - 1);
-});
-  $('.modal.in:visible:last').focus().next('.modal-backdrop.in').removeClass('hidden');
-}
+// function setModalsAndBackdropsOrder() {  
+//   var modalZIndex = 1040;
+//   $('.modal.in').each(function(index) {
+//     var $modal = $(this);
+//     modalZIndex++;
+//     $modal.css('zIndex', modalZIndex);
+//     $modal.next('.modal-backdrop.in').addClass('hidden').css('zIndex', modalZIndex - 1);
+// });
+//   $('.modal.in:visible:last').focus().next('.modal-backdrop.in').removeClass('hidden');
+// }

--- a/app/views/flash_teams/_task_modal.html.erb
+++ b/app/views/flash_teams/_task_modal.html.erb
@@ -14,3 +14,20 @@
     <button class="btn btn-primary" id="edit-save-task" onclick="editTaskOverview(true)">Edit</button> -->
   </div> 
 </div>
+
+<!-- Task Modal (triggered when an event block on timeline is clicked on) -->
+<div id="task_modal2" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="task_modal_Label2" aria-hidden="true">
+  <div class="modal-header">
+    <button type="button" class="close" id="modal-close-btn2" data-dismiss="modal" aria-hidden="true">×</button>
+    <h3 id="task_modal_Label2"></h3>
+
+  </div>
+  <div class="modal-body task-modal-body2">
+   <p id="task-text2">Task Description</p>
+    <!--<p><span id="task-edit-link"></span></p> -->
+  </div>
+  <div class="modal-footer task-modal-footer2">
+    <!-- <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    <button class="btn btn-primary" id="edit-save-task" onclick="editTaskOverview(true)">Edit</button> -->
+  </div> 
+</div>


### PR DESCRIPTION
This PR changes the way inputs from handoffs and collaborations are displayed and described on the task modals. Specifically, I separated inputs from handoffs from inputs from collaborations and updated the text describing what to do with each of them. 

For example, a task that has inputs from handoffs and collaborations would look like this: 
![image](https://cloud.githubusercontent.com/assets/5275384/7335175/879b2b74-eb61-11e4-8c8d-ea114cd2834c.png)

If there is a handoff from a task without an output listed or if there is a collaboration with a task without any inputs, the name of the outputs on the task modal is replaced with either 'prior task results' or 'collaboration' -- Specifically, the task modal would look like this: 

![image](https://cloud.githubusercontent.com/assets/5275384/7335182/0abe644e-eb62-11e4-85a6-2e4ff73eb7a4.png)

If you click on the name of the task (under the linked deliverables) for the handoffs and collaborations on the task modal, it opens another task modal that has all of the information about that task. The modal is stacked on top of the original event's modal so that when you close it, you go back to the event modal you were looking at. On the footer of the stacked task modal, there is a button to go to the google drive folder for that task. The stacked modal looks like this: 

![image](https://cloud.githubusercontent.com/assets/5275384/7335186/6d4ed436-eb62-11e4-8ada-16f16164c7af.png)
