### PR TITLE
Dr int popovers fix

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -766,6 +766,7 @@ var startTeam = function(firstTime){
         $("#projectStatusText").toggleClass('projectStatusText-inactive', true);
         
         flashTeamsJSON["paused"]=false;
+        updateInteractionsPopovers();
 
         logActivity("var startTeam = function(firstTime) - Before Update Status",'Start Team - Before Update Status', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
 

--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -109,7 +109,7 @@ $("#flashTeamStartBtn").click(function(){
 });
 
 function disableTeamEditing() {
-   
+    updateInteractionsPopovers(); //update interaction popovers to read only mode
 
     $(".add-folder-button").addClass("disabled");
     $(".add-role").addClass("disabled");
@@ -122,7 +122,7 @@ function disableTeamEditing() {
 }
 
 function enableTeamEditing() {
-    
+    updateInteractionsPopovers(); //update interaction popovers to edit mode
     
     $(".add-folder-button").removeClass("disabled");
     $(".add-role").removeClass("disabled");
@@ -148,8 +148,6 @@ function startFlashTeam() {
     $("div#chat-box-container").css('display','');
     $("#flashTeamTitle").css('display','none');
     
-    
-
     disableTeamEditing();
     
     removeColabBtns();
@@ -1306,6 +1304,29 @@ var drawInteractions = function(tasks){
         drawCollaboration(remainingCollabs[k], overlap);
     }
 };
+
+//Updates all the interaction popovers that involve the "tasks"
+//Note: if "tasks" is undefined, updates all interaction popovers
+//This is used to update the interaction popovers to edit mode or read only depending on the state of the team
+var updateInteractionsPopovers = function(tasks){
+    //Find Remaining Interactions and Draw
+    var remainingHandoffs = getHandoffs(tasks);
+    var numHandoffs = remainingHandoffs.length;
+
+    var remainingCollabs = getCollabs(tasks);
+    var numCollabs = remainingCollabs.length;
+
+    for (var j = 0; j < numHandoffs; j++) {
+        var intId = remainingHandoffs[j].id
+        updateHandoffPopover(intId);
+    }
+
+    for (var k = 0; k < numCollabs; k++) {
+        var intId = remainingCollabs[k].id; 
+        updateCollabPopover(intId);
+    }
+};
+
 
 var moveTasksRight = function(tasks, amount, from_initial){
     var len = tasks.length;

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -267,7 +267,7 @@ function drawHandoffPopover(handoffId, ev1, ev2) {
         title: 'Handoff from "' + ev1.title + '" to "' + ev2.title + '"',
         content: 'Description of Handoff Materials: '
         + getHandoffInfo(handoffId),
-        container: $("#timeline-container")
+        container: $(".container-fluid") //used to be #timeline-container but would get squished if event was near chat
     });
 
     $("#interaction_" + handoffId).on('click', function() { 
@@ -462,7 +462,7 @@ function drawCollabPopover(collabId, ev1, ev2) {
         title: 'Collaboration between "' + ev1.title + '" and "' + ev2.title + '"',
         content: 'Description of Collaborative Work: '
         + getCollabInfo(collabId),
-        container: $("#timeline-container")
+        container: $(".container-fluid") //used to be #timeline-container but would get squished if event was near chat
     });
 
     $("#interaction_" + collabId).on('click', function() { 

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -251,6 +251,13 @@ function drawHandoff(handoffData) {
             else d3.select(this).style("stroke", "gray");
         });
 
+
+    //Draw a popover to display information about the collaboration
+    drawHandoffPopover(handoffId, ev1, ev2);
+}
+
+//Add a popover to the collaboration rect so the user can add notes and delete
+function drawHandoffPopover(handoffId, ev1, ev2) {
     //Popover that stores information about the handoff
     $("#interaction_" + handoffId).popover({
         class: "handoffPopover", 
@@ -267,8 +274,14 @@ function drawHandoff(handoffData) {
         logActivity("drawHandoff(handoffData)",'Show Handoff', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["interactions"][getIntJSONIndex(handoffId)]);
 
     });
-
 }
+
+// updates the handoff popover to either edit or read only mode depending on status of team
+function updateHandoffPopover(handoffId){
+    $("#interaction_" + handoffId).data('popover').options.content = 'Description of Handoff Materials: '
+        + getHandoffInfo(handoffId);
+}
+
 
 //Calculate where the physical handoff starts
 function handoffStart(firstEvent){
@@ -456,6 +469,12 @@ function drawCollabPopover(collabId, ev1, ev2) {
         logActivity("drawCollabPopover(collabId, ev1, ev2)",'Show Handoff', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["interactions"][getIntJSONIndex(collabId)]);
 
     });
+}
+
+// updates the collab popover to either edit or read only mode depending on status of team
+function updateCollabPopover(collabId){
+    $("#interaction_" + collabId).data('popover').options.content = 'Description of Collaborative Work: '
+        + getCollabInfo(collabId);
 }
 
 //TODO: COMMENT


### PR DESCRIPTION
This pull request properly updates the interaction popovers for handoffs and collaborations. Previously, when you would start the team, the interaction popovers would remain in edit mode until you refreshed the page. Similarly, if you would click edit team, the popovers would remain in read only mode until you refreshed the page. Same thing would happen when you would click save team, the popovers would remain in read only mode until you refreshed the page. 

The popovers should now switch to read only mode right when you click start team, switch to edit mode right when you click edit team and switch back to read only mode when you click save team. 

Also, I attached the popover containers to ".container-fluid" instead of "#timeline-container" because they were getting squished if the event was too close to the chat. This means that when an event is close to the chat, the popover will go over the chat like so: 

![image](https://cloud.githubusercontent.com/assets/5275384/7339816/413235fe-ec30-11e4-9a53-09949def202b.png)


To test: 
1) Create a team, add events and handoffs and collaborations
2) Start the team and click the handoff and collaboration popovers (BEFORE REFRESHING THE PAGE)
3) Refresh the page and make sure the popovers are still in read only mode
4) Click edit team and then click the popovers and make sure the popovers are in edit mode
5) Save the team and then click the popovers and make sure the popovers are in read only mode
6) Make your window less wide so that the timeline doesn't take up much width (e.g., the chat and left menu are closer together). Click on the popovers and make sure they look ok and aren't squished. 
