### PR TITLE
Dr event fixes

### DIFF
--- a/app/assets/javascripts/authoring/eventDetails.js
+++ b/app/assets/javascripts/authoring/eventDetails.js
@@ -297,15 +297,18 @@ if(!window._foundry) {
       tag: "image",
       attrs: {
           x: function(d) {
+              var groupNum = parseInt(d.id.replace("task_g_", ""));
+              var eventObj = getEventFromId(groupNum);
               var attrs = events.numMembers.attrs;
-              return attrs.x(d) + 15;
+              //return attrs.x(d) + 15;
+              return eventObj.duration <= 60 ? attrs.x(d) - 4 : attrs.x(d) + 15;
           },
           y: function(d) {return d.y + events.bodyHeight - 18},
           width: function(d) {
               var groupNum = parseInt(d.id.replace("task_g_", ""));
               var eventObj = getEventFromId(groupNum);
-              // set the width to zero if this is an hour long event
-              return eventObj.duration <= 60 ? 0 : 12;
+              // set the width to zero if the duration of event is 45 mins or less
+              return eventObj.duration <= 45 ? 0 : 12;
           },
           height: 12,
           "xlink:href": function(d) {

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -367,9 +367,9 @@ function showDropDown(){
                 }
             },
             "duplicate": {name: "Duplicate", icon: ""},
-            "confirmDelete": {name: "Delete", icon: "", disabled: function(key, opt) { 
-                    return ((getEventFromId(CURRENT_EVENT_SELECTED).status == "completed") || (getEventFromId(CURRENT_EVENT_SELECTED).status == "started") || (getEventFromId(CURRENT_EVENT_SELECTED).status == "delayed"));
-                }}
+            "confirmDelete": {name: "Delete", icon: ""//, disabled: function(key, opt) { 
+                    //return ((getEventFromId(CURRENT_EVENT_SELECTED).status == "completed") || (getEventFromId(CURRENT_EVENT_SELECTED).status == "started") || (getEventFromId(CURRENT_EVENT_SELECTED).status == "delayed"));
+                }//}
         }
     });
 }
@@ -678,8 +678,13 @@ function deleteEvent(eventId){
     // Only log before because event won't exist after
     logActivity("deleteEvent(eventId)",'Delete Event - Before', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(eventId)]);
 
-    //Delete the event object from the json
+    
     var indexOfJSON = getEventJSONIndex(eventId);
+
+    var eventObj = flashTeamsJSON["events"][indexOfJSON];
+    var eventStatus = eventObj.status;
+
+    //Delete the event object from the json
     var events = flashTeamsJSON["events"];
     events.splice(indexOfJSON, 1);
     
@@ -698,6 +703,30 @@ function deleteEvent(eventId){
     for (var i = 0; i < intersToDel.length; i++) {
         var intId = intersToDel[i];
         deleteInteraction(intId);
+    }
+
+
+    if(eventStatus != 'not_started'){
+        if(live_tasks.indexOf(eventId) != -1){
+            live_tasks.splice(live_tasks.indexOf(eventId), 1);
+        }
+
+        if(paused_tasks.indexOf(eventId) != -1){
+            paused_tasks.splice(paused_tasks.indexOf(eventId), 1);
+        }
+
+        if(delayed_tasks.indexOf(eventId) != -1){
+            delayed_tasks.splice(delayed_tasks.indexOf(eventId), 1);
+        }
+
+        if(completed_red_tasks.indexOf(eventId) != -1){
+            completed_red_tasks.splice(completed_tasks.indexOf(eventId), 1);
+        }
+
+        if(drawn_blue_tasks.indexOf(eventId) != -1){
+            drawn_blue_tasks.splice(drawn_blue_tasks.indexOf(eventId), 1);
+        }
+
     }
 
     //Visually removes task from the timeline, in awareness.js

--- a/app/assets/javascripts/authoring/events.js
+++ b/app/assets/javascripts/authoring/events.js
@@ -374,7 +374,7 @@ function showDropDown(){
     });
 }
 
-function duplicateEvent(groupNumber){
+function duplicateEvent(groupNumber, closeModal){
     var task_id = getEventJSONIndex(groupNumber);
     var eventToDuplicate = flashTeamsJSON["events"][task_id];
 
@@ -402,8 +402,13 @@ function duplicateEvent(groupNumber){
         createTaskFolder(flashTeamsJSON["events"][event_index].title, event_index, flashTeamsJSON.folder[0]);
     }
 
-    logActivity("duplicateEvent(groupNumber)",'Clicked Duplicate Event on Config Dropdown', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNumber)]);    
+    if(closeModal == true){
+        $('#task_modal').modal('hide'); 
+        logActivity("duplicateEvent(groupNumber)",'Clicked Duplicate Event Button on Task Modal', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNumber)]);    
 
+    }else{
+        logActivity("duplicateEvent(groupNumber)",'Clicked Duplicate Event on Config Dropdown', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNumber)]);    
+    }
     // save
     updateStatus();
 }

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -26,8 +26,9 @@ function eventMousedown(task2idNum) {
        var modal_body = '<p id="task-text"></p>' +
        '<p><span id="task-edit-link"></span></p>';
 
-       var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logTaskOverviewGDriveBtnClick(' + task_id  + ')">Deliverables Folder</a>' + 
+       var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logTaskOverviewGDriveBtnClick(' + task_id  + ')">Deliverables</a>' + 
        '<button class="btn " id="hire-task" style="float :left " onclick="hireForm('+task2idNum+')">Hire</button>' +
+       '<button class="btn " id="duplicate-task" style="float :left " onclick="duplicateEvent('+task2idNum+', true)">Duplicate</button>' +
        '<button class="btn " id="start-end-task" style="float :right " onclick="confirm_show_docs('+task2idNum+')">Start</button>'+
        '<button class="btn " id="pause-resume-task" style="float :right " onclick="pauseTask('+task2idNum+')">Take a Break</button>'+
        '<button class="btn" id="edit-save-task" onclick="editTaskOverview(true,'+task2idNum+')">Edit</button>' +

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -57,7 +57,7 @@ function showTaskOverview(groupNum){
              $("#start-end-task").css('display', '');
               $("#start-end-task").html('Complete');
               $("#start-end-task").addClass('btn-success');
-              $("#start-end-task").prop('disabled', true)
+              $("#start-end-task").prop('disabled', true);
         }
         else{
            $("#pause-resume-task").css('display', 'none'); 

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -73,9 +73,15 @@ function showTaskOverview(groupNum){
 
     if(uniq_u == "" || memberType == "pc" || memberType == "client"){
         $("#hire-task").css('display','');
+        $("#duplicate-task").css('display','');
     }
     else{
         $("#hire-task").css('display','none');
+        $("#duplicate-task").css('display','none');
+    }
+
+    if(in_progress == true && flashTeamsJSON["paused"]==true && (uniq_u == "" )){
+        $("#duplicate-task").css('display','');
     }
     
 	if(in_progress != true && (uniq_u == "" || memberType == "pc" || memberType == "client") ) {
@@ -86,13 +92,14 @@ function showTaskOverview(groupNum){
 	} //only the author can edit tasks if the projec is in progress. The delayed, completed, and started tasks cannot be edited.
     else if(in_progress == true && flashTeamsJSON["paused"]==true && (uniq_u == "" ) && (eventObj.status != "started" && eventObj.status != "delayed" && eventObj.status != "completed")) {
             $("#edit-save-task").css('display', '');
-            
+            //$("#duplicate-task").css('display','');
             $("#edit-save-task").attr('onclick', 'editTaskOverview(true,'+groupNum+')');
             $("#edit-save-task").html('Edit');
     }
 	else{
 		$("#edit-save-task").css('display', 'none');
 		$("#delete").css('display','none');
+        //$("#duplicate-task").css('display','none');
 	}
     logActivity("showTaskOverview(groupNum)",'Show Task Overview', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
 }
@@ -119,7 +126,7 @@ function showShortTaskOverview(groupNum){
         $('#task-text2').html(taskOverviewContent);
 
         var modal_footer = '<button class="btn" data-dismiss="modal" aria-hidden="true" style="float: right" onclick="logHideShortTaskOverview(' + groupNum  + ')">Close</button>'
-                            + '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Deliverables Folder</a>';
+                            + '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logShortTaskOverviewGDriveBtnClick(' + groupNum  + ')">Deliverables</a>';
 
         $('.task-modal-footer2').html(modal_footer);
         


### PR DESCRIPTION
Fixes: 
#332 
#330 

Specifically, I did the following: 
- added the configuration icon (which lets you duplicate, edit, view and delete event) to events that are 1 hour long (previously the icon would disappear). Now the icon only disappears when events are 45 mins or shorter.

- added a "Duplicate" task button to the footer of the task modal, which should duplicate the event and close the task modal when clicked on. The duplicate task button should only appear when the project hasn't been started or when the team is in edit mode. Workers should not be able to see the duplicate task button though (it should only be visible to authors, clients and PCs). 

- fixed the bug that caused the entire team to break if a task that had been started, delayed or paused was erased. Previously, the events were only removed from the flash team JSON but not from the live_tasks, paused_tasks, completed_red_tasks, drawn_blue_tasks or _delayed_tasks arrays, which caused problems when adding the tasks to the timeline. 

- added the ability to erase completed events. The delete event option in the dropdown is activated (eventually we might also consider adding a delete button to the footer of the task modal but for now it is hidden). 

Testing instructions (read step 5 before creating team so you have an idea of what you will need to test): 
1. Create a team and add a bunch of events (make sure at least a couple of the events are 1 hour long)
2. Add a member and assign the member to some of the events. Open the team in worker view so that you have both author view and worker view open at the same time
3. For the 1 hour events, make sure that you can see the config icon. For all of the events, in author view, make sure you see the duplicate button in the footer. Try clicking it and make sure the event duplicates and that the task modal closes.
4. Start the team. The config icons and the duplicate button on the task modal should both disappear. Edit the team. The icon and duplicate button should re-appear (in author view). 
5. Return to non-edit mode. Start a bunch of the tasks. Let one of the tasks get delayed, pause a different task, complete a different task and let another task just be in progress. Try erasing each of the events, refresh the page and make sure there are no bugs. You might also consider adding interactions and collaborations between some of the events and make sure they delete properly. 

That should be all! 