### PR TITLE
removed polling for trackUpcomingEvent function 

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -364,6 +364,7 @@ function renderEverything(firstTime) {
             }
 
             renderMembersUser();
+            trackUpcomingEvent();
 
             //call this function if team is not in the edit mode 
             if(isUser){
@@ -1473,71 +1474,71 @@ offset of half of drag bar width when drawing red and blue boxes
 */
 // not being called for user's side
 // trying to fix issue of user's page not extending delayed box (and moving remaining tasks to the right)
-var trackLiveAndRemainingTasks = function() {
-    tracking_tasks_interval_id = setInterval(function(){
-        var tasks = computeLiveAndRemainingTasks();
-        var new_live_tasks = tasks["live"];
-        var new_remaining_tasks = tasks["remaining"];
+// var trackLiveAndRemainingTasks = function() {
+//     tracking_tasks_interval_id = setInterval(function(){
+//         var tasks = computeLiveAndRemainingTasks();
+//         var new_live_tasks = tasks["live"];
+//         var new_remaining_tasks = tasks["remaining"];
 
-        // extend already delayed boxes
-        extendDelayedBoxes();
+//         // extend already delayed boxes
+//         extendDelayedBoxes();
 
-        var at_least_one_task_started = false;
-        var at_least_one_task_delayed = false;
+//         var at_least_one_task_started = false;
+//         var at_least_one_task_delayed = false;
 
-        // detect any live task is now delayed or completed early
-        for (var i=0;i<live_tasks.length;i++){
-            var groupNum = parseInt(live_tasks[i]);
-            var task_g = getTaskGFromGroupNum (groupNum);
-            var ev = flashTeamsJSON["events"][getEventJSONIndex(groupNum)];
-            var completed = ev.completed_x;
-            var task_rect_curr_width = parseFloat(getWidth(ev));
+//         // detect any live task is now delayed or completed early
+//         for (var i=0;i<live_tasks.length;i++){
+//             var groupNum = parseInt(live_tasks[i]);
+//             var task_g = getTaskGFromGroupNum (groupNum);
+//             var ev = flashTeamsJSON["events"][getEventJSONIndex(groupNum)];
+//             var completed = ev.completed_x;
+//             var task_rect_curr_width = parseFloat(getWidth(ev));
 
-            // delayed
-            if (new_live_tasks.indexOf(groupNum) == -1 && !completed) { // groupNum is no longer live
-                console.log("PREVIOUSLY LIVE TASK NOW DELAYED!");
-                drawRedBox(ev, task_g, false);
+//             // delayed
+//             if (new_live_tasks.indexOf(groupNum) == -1 && !completed) { // groupNum is no longer live
+//                 console.log("PREVIOUSLY LIVE TASK NOW DELAYED!");
+//                 drawRedBox(ev, task_g, false);
 
-                // add to delayed_tasks list
-                delayed_tasks.push(groupNum);
+//                 // add to delayed_tasks list
+//                 delayed_tasks.push(groupNum);
                 
-                // updateStatus is required to send the notification email when a task is delayed
-                delayed_tasks_time[groupNum]=(new Date).getTime();
+//                 // updateStatus is required to send the notification email when a task is delayed
+//                 delayed_tasks_time[groupNum]=(new Date).getTime();
 
-                at_least_one_task_delayed = true;
-            }
-        }
+//                 at_least_one_task_delayed = true;
+//             }
+//         }
       
         
 
        
 
-        var tasks_tmp = MoveLiveToRemaining(new_live_tasks,new_remaining_tasks);
-        new_live_tasks = tasks_tmp["live"];
-        new_remaining_tasks = tasks_tmp["remaining"];
+//         var tasks_tmp = MoveLiveToRemaining(new_live_tasks,new_remaining_tasks);
+//         new_live_tasks = tasks_tmp["live"];
+//         new_remaining_tasks = tasks_tmp["remaining"];
         
-        for (var j=0;j<remaining_tasks.length;j++){
-            var groupNum = parseInt(remaining_tasks[j]);
-            if (new_live_tasks.indexOf(groupNum) != -1) { // groupNum is now live
-                at_least_one_task_started = true;
-            }
-        }
+//         for (var j=0;j<remaining_tasks.length;j++){
+//             var groupNum = parseInt(remaining_tasks[j]);
+//             if (new_live_tasks.indexOf(groupNum) != -1) { // groupNum is now live
+//                 at_least_one_task_started = true;
+//             }
+//         }
 
-        live_tasks = new_live_tasks;
-        remaining_tasks = new_remaining_tasks;
+//         live_tasks = new_live_tasks;
+//         remaining_tasks = new_remaining_tasks;
        
         
 
-        if(at_least_one_task_delayed || at_least_one_task_started){
-            //updateStatus(true);
-            updateStatus();
-            if(at_least_one_task_delayed)
-                at_least_one_task_delayed = false;
-            if(at_least_one_task_started)
-                at_least_one_task_started = false;
-        }
-    }, fire_interval);
-};
+//         if(at_least_one_task_delayed || at_least_one_task_started){
+//             //updateStatus(true);
+//             updateStatus();
+//             if(at_least_one_task_delayed)
+//                 at_least_one_task_delayed = false;
+//             if(at_least_one_task_started)
+//                 at_least_one_task_started = false;
+//         }
+//     }, fire_interval);
+// };
 
 //moves live task to remaining task if prev task is delayed
 function MoveLiveToRemaining(new_live_tasks,new_remaining_tasks){
@@ -1650,7 +1651,7 @@ var trackUpcomingEvent = function(){
         return;
     }
     
-    setInterval(function(){
+    //setInterval(function(){
 
         var overallTime;
         
@@ -1761,7 +1762,7 @@ var trackUpcomingEvent = function(){
         }
 
 
-    }, fire_interval);
+    //}, fire_interval);
 }
 
 // updates the project status text in the sidebar

--- a/app/assets/javascripts/authoring/taskStatus.js
+++ b/app/assets/javascripts/authoring/taskStatus.js
@@ -88,6 +88,7 @@ function startTask(groupNum) {
 
     updateStatus();
     drawEvent(eventObj); //Will update color
+    trackUpcomingEvent();
 
     //Close the task modal
     //$("#task_modal").modal('hide');
@@ -119,6 +120,7 @@ function pauseTask(groupNum) {
 
     updateStatus();
     drawEvent(eventObj); //Will update color
+    trackUpcomingEvent();
 	
 
 	//chaning resume button to pause button on the task modal
@@ -155,6 +157,7 @@ function resumeTask(groupNum) {
    
     updateStatus();
     drawEvent(eventObj); //Will update color
+    trackUpcomingEvent();
 
 
 	//chaning start button to complete button on the task modal
@@ -295,7 +298,7 @@ var allCompleted = function(eventToComplete){
     if (totalCheckboxes != checkedCheckboxes) {
         completed = false;
     }
-    return completed
+    return completed;
 }
 
 var keyUpFunc = function(eventToComplete){
@@ -503,6 +506,7 @@ var completeTask = function(groupNum){
     flashTeamsJSON['local_update'] = new Date().getTime();
     updateStatus();
     drawEvent(eventToComplete);
+    trackUpcomingEvent();
 
     //Message the PC that the task has been completed
     //TODO


### PR DESCRIPTION
Previously, the trackUpcomingEvent function was polling every few seconds to see if the text in the sidebar with the user's task status needed to be updated. This seemed extremely inefficient. For example, if you would open the inspector and hover over the code for the sidebar text, the code would flicker because ti was constantly being updated.

Therefore, in attempt to fix this, I commented out the interval code and instead called trackUpcomingEvent() at different points when the task status changed. For example, when the task is started, paused, resumed, completed, etc. I also added it to the renderEverything function.

When testing: 
1) Create a team, add tasks and assign them to at least one member
2) Open the team in the worker's view
3) Start the team 
4) In worker view, make sure the status text updates correctly in the sidebar and the top alert bar. Specifically: 
- start a task and make sure the text changes to 'your task is in progress' and the 'take a break' and 'complete' buttons appear. 
- pause the task and make sure the text changes to 'your task is paused' and the 'resume' button appears 
- resume the task and make sure the text changes to 'your task is in progress' or 'your task is delayed' along with the corresponding buttons
- let the task get delayed and make sure the task and buttons update correctly
- complete the task and make sure the status task and buttons update correctly. If you have another task, it should let you know if it is ready to be started and if you have completed all of your tasks it should tell you that. 

Please try and test other edge cases (multiple users, no tasks assigned to the worker, etc.) as I am sure I probably forgot some. Thanks! 

