### PR TITLE
added clone function

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Foundry::Application.routes.draw do
       get :task_portal
       get :settings
       get :duplicate
+      get :clone
       post :settings
     end
   end


### PR DESCRIPTION
Added clone feature, which copies over status information but replaces the member URLs. For now, the google drive folders copy over exactly and if you add tasks to team they are added to the ORIGINAL team. We will need to fix this soon.