### PR TITLE
Dr starter task

### DIFF
--- a/app/assets/javascripts/authoring/panels.js
+++ b/app/assets/javascripts/authoring/panels.js
@@ -118,6 +118,16 @@ function insertFoundryLink(sel){
 	$("#foundry_member_url").val(foundry_member_url);
 }
 
+function showMemberTasks(sel){
+	link = sel.value.split(',');
+	console.log('sel: ' + sel.value);
+	console.log('link: ' + link[1].substring(2, link[1].length-2));
+	// foundry_member_url = link[1].substring(2, link[1].length-2);
+	// console.log("link: " + link[1].substring(2, link[1].length-2));
+
+	// $("#foundry_member_url").val(foundry_member_url);
+}
+
 function hideRightPanels(){	
 	$("#hidePanelsLink").html('View Panels');
 	$("#right-sidebar-wrapper").css('display', 'none');

--- a/app/assets/javascripts/authoring/panels.js
+++ b/app/assets/javascripts/authoring/panels.js
@@ -118,16 +118,6 @@ function insertFoundryLink(sel){
 	$("#foundry_member_url").val(foundry_member_url);
 }
 
-function showMemberTasks(sel){
-	link = sel.value.split(',');
-	console.log('sel: ' + sel.value);
-	console.log('link: ' + link[1].substring(2, link[1].length-2));
-	// foundry_member_url = link[1].substring(2, link[1].length-2);
-	// console.log("link: " + link[1].substring(2, link[1].length-2));
-
-	// $("#foundry_member_url").val(foundry_member_url);
-}
-
 function hideRightPanels(){	
 	$("#hidePanelsLink").html('View Panels');
 	$("#right-sidebar-wrapper").css('display', 'none');

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -535,31 +535,31 @@ end
    end
    
    
-     def hire_form
-	   	   	
-	   	@id_team = params[:id]
-	   	@id_task = params[:event_id].to_i
-	   	
-	   	@task_avail_active = "active"
+  def hire_form
+   	   	
+   	@id_team = params[:id]
+   	@id_task = params[:event_id].to_i
+   	
+   	@task_avail_active = "active"
 
-		@flash_team = FlashTeam.find(params[:id])
-   		   	
-   		@workers = Worker.all.order(name: :asc)
+	  @flash_team = FlashTeam.find(params[:id])
+ 		   	
+ 		@workers = Worker.all.order(name: :asc)
+
+ 		@panels = Worker.distinct.pluck(:panel)
+
+ 		@fw = Worker.all.pluck(:email)   
+   	    
+   	# Extract data from the JSON
+    flash_team_status = JSON.parse(@flash_team.status)
+    @flash_team_json = flash_team_status['flash_teams_json']
+    #@flash_team_event = flash_team_status['flash_teams_json']['events'][@id_task]
+    @flash_team_event = @flash_team_json['events'][@id_task]
+    
+    minutes = @flash_team_event['duration']
+	  hh, mm = minutes.divmod(60)
+	  @task_duration = hh.to_s 
 	
-   		@panels = Worker.distinct.pluck(:panel)
-	
-   		@fw = Worker.all.pluck(:email)   
-	   	    
-	   	# Extract data from the JSON
-	    flash_team_status = JSON.parse(@flash_team.status)
-	    @flash_team_json = flash_team_status['flash_teams_json']
-	    #@flash_team_event = flash_team_status['flash_teams_json']['events'][@id_task]
-	    @flash_team_event = @flash_team_json['events'][@id_task]
-	    
-	    minutes = @flash_team_event['duration']
-		hh, mm = minutes.divmod(60)
-		@task_duration = hh.to_s 
-		
 		if hh==1
 			@task_duration += " hour"
 		else
@@ -569,19 +569,19 @@ end
 		if mm>0
 			@task_duration += " and " + mm.to_s + " minutes"
 		end
-	    
-	    #array for all members associated with this event
-	    @task_members = Array.new
-	    
-	    # Add all the members associated with event to @task_members array
-	    @flash_team_event['members'].each do |task_member|
-	    	@task_members << getMemberById(@id_team, @id_task, task_member)
-	    end
-	    
-	    @task_avail_email_subject = "From Stanford HCI Group: " + @flash_team_event["title"] + " Task Is Available"
-   		@url1 = url_for :controller => 'flash_teams', :action => 'listQueueForm', :id => @id_team, :event_id => @id_task.to_s
-   
-	     end
+    
+    #array for all members associated with this event
+    @task_members = Array.new
+    
+    # Add all the members associated with event to @task_members array
+    @flash_team_event['members'].each do |task_member|
+    	@task_members << getMemberById(@id_team, @id_task, task_member)
+    end
+    
+    @task_avail_email_subject = "From Stanford HCI Group: " + @flash_team_event["title"] + " Task Is Available"
+ 		@url1 = url_for :controller => 'flash_teams', :action => 'listQueueForm', :id => @id_team, :event_id => @id_task.to_s
+ 
+ end
   
   def send_task_available
 
@@ -652,6 +652,126 @@ end
    			UserMailer.send_task_hiring_email(@sender_email, email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @url).deliver
    		end
    
+   end
+
+
+   def starter_task
+        
+    @id_team = params[:id]
+    @id_task = params[:event_id].to_i
+    
+    @starter_task_active = "active"
+
+    @flash_team = FlashTeam.find(params[:id])
+        
+    @workers = Worker.all.order(name: :asc)
+
+    @panels = Worker.distinct.pluck(:panel)
+
+    @fw = Worker.all.pluck(:email)   
+        
+    # Extract data from the JSON
+    flash_team_status = JSON.parse(@flash_team.status)
+    @flash_team_json = flash_team_status['flash_teams_json']
+    #@flash_team_event = flash_team_status['flash_teams_json']['events'][@id_task]
+    @flash_team_event = @flash_team_json['events'][@id_task]
+    
+    minutes = @flash_team_event['duration']
+    hh, mm = minutes.divmod(60)
+    @task_duration = hh.to_s 
+  
+    if hh==1
+      @task_duration += " hour"
+    else
+      @task_duration += " hours"
+    end
+    
+    if mm>0
+      @task_duration += " and " + mm.to_s + " minutes"
+    end
+    
+    #array for all members associated with this event
+    @task_members = Array.new
+    
+    # Add all the members associated with event to @task_members array
+    @flash_team_event['members'].each do |task_member|
+      @task_members << getMemberById(@id_team, @id_task, task_member)
+    end
+    
+    @starter_task_email_subject = "Starter Task From Stanford HCI Group: " + @flash_team_event["title"] #+ " Task Is Available"
+    @url1 = url_for :controller => 'flash_teams', :action => 'listQueueForm', :id => @id_team, :event_id => @id_task.to_s
+ 
+ end
+
+ def send_starter_task
+
+    @id_team = params[:id]
+    @id_task = params[:event_id].to_i
+    
+    @starter_task_active = "active";
+    
+    @flash_team = FlashTeam.find(params[:id])
+        
+    # Extract data from the JSON
+    flash_team_status = JSON.parse(@flash_team.status)
+    @flash_team_json = flash_team_status['flash_teams_json']
+    @flash_team_event = @flash_team_json['events'][@id_task]
+    
+    if !params[:sender_email].empty?
+      @sender_email = params[:sender_email]
+    else
+      @sender_email = ENV['DEFAULT_EMAIL']
+    end
+    
+    @flash_team_name = @flash_team_json['title']
+    
+    @task_member = params[:task_member] #i.e. role of recipient 
+    @recipient_email = params[:recipient_email]
+    @subject = params[:subject]
+    
+    @task_name = params[:task_name]
+    @project_overview = params[:project_overview]
+    @task_description = params[:task_description]
+    
+    
+    @all_inputs = params[:all_inputs]
+    @input_link = params[:input_link]
+    
+    @outputs = params[:outputs]
+    @output_description = params[:output_description]
+    
+    @task_duration = params[:task_duration]
+    
+    #@message = params[:message]
+
+    @task_members = Array.new
+    @flash_team_event['members'].each do |task_member|
+      @task_members << getMemberById(@id_team, @id_task, task_member)
+    end
+    @uniq = ""
+    @task_members.each do |task_member|
+      if task_member['role'] == @task_member
+        @uniq = task_member['uniq']
+          break
+      end
+    end
+
+    #@message = "<p>This is an email from the Stanford HCI Group notifying you that a job requiring a #{@task_member} for the #{@task_name} task for the #{@flash_team_json['title']} project has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within the specified deadline.</p>"
+    emails = @recipient_email.split(',')
+    @url1 = url_for :controller => 'flash_teams', :action => 'listQueueForm', :id => @id_team, :event_id => @id_task.to_s
+    for email in emails
+      newLanding = Landing.new
+      newLanding.id_team = @id_team
+      newLanding.id_event = @id_task
+      newLanding.email = email.strip
+      newLanding.task_member = @task_member
+      newLanding.status = 's'
+      newLanding.uniq = @uniq
+      newLanding.save
+      @url = url_for :controller => 'landings', :action => 'view', :id => @id_team, :event_id => @id_task.to_s, :task_member => @task_member, :uniq => @uniq, :email => email.strip
+      UserMailer.send_starter_task_email(@sender_email, email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @url).deliver
+    end
+  
    end
    
       

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -741,6 +741,7 @@ end
     @output_description = params[:output_description]
     
     @task_duration = params[:task_duration]
+    @compensation_info = params[:compensation_info]
     
     #@message = params[:message]
 
@@ -769,7 +770,7 @@ end
       newLanding.uniq = @uniq
       newLanding.save
       @url = url_for :controller => 'landings', :action => 'view', :id => @id_team, :event_id => @id_task.to_s, :task_member => @task_member, :uniq => @uniq, :email => email.strip
-      UserMailer.send_starter_task_email(@sender_email, email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @url).deliver
+      UserMailer.send_starter_task_email(@sender_email, email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @compensation_info, @url).deliver
     end
   
    end

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -769,7 +769,7 @@ end
       newLanding.status = 's'
       newLanding.uniq = @uniq
       newLanding.save
-      @url = url_for :controller => 'landings', :action => 'view', :id => @id_team, :event_id => @id_task.to_s, :task_member => @task_member, :uniq => @uniq, :email => email.strip
+      @url = url_for :controller => 'landings', :action => 'view', :id => @id_team, :event_id => @id_task.to_s, :task_member => @task_member, :uniq => @uniq, :email => email.strip, :starter_task =>"true"
       UserMailer.send_starter_task_email(@sender_email, email, @subject, @flash_team_name, @task_member, @task_name, @project_overview, @task_description, @all_inputs, @input_link, @outputs, @output_description, @task_duration, @compensation_info, @url).deliver
     end
   

--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -2,7 +2,6 @@ class LandingsController < ApplicationController
   def view
     if params[:starter_task] == "true"
       @starter_task = true
-      #flash[:notice] = "starter task"
     else
       @starter_task = "false"
     end

--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -1,5 +1,11 @@
 class LandingsController < ApplicationController
   def view
+    if params[:starter_task] == "true"
+      @starter_task = true
+      #flash[:notice] = "starter task"
+    else
+      @starter_task = "false"
+    end
     @id_team = params[:id]
     @id_task = params[:event_id].to_i
     @flash_team = FlashTeam.find(params[:id])

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -77,7 +77,7 @@ class UserMailer < ActionMailer::Base
   	mail(:from => sender_email, :bcc => recipient_email, :subject => subject)
   end
 
-  def send_starter_task_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration, url)
+  def send_starter_task_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration, compensation_info, url)
   
     #@message = message.html_safe
     @flash_team_name = flash_team_name
@@ -90,6 +90,7 @@ class UserMailer < ActionMailer::Base
     @outputs = outputs
     @output_description = output_description
     @task_duration = task_duration
+    @compensation_info = compensation_info
     @url = url
               
     mail(:from => sender_email, :bcc => recipient_email, :subject => subject)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -76,6 +76,24 @@ class UserMailer < ActionMailer::Base
   		    	  
   	mail(:from => sender_email, :bcc => recipient_email, :subject => subject)
   end
+
+  def send_starter_task_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration, url)
+  
+    #@message = message.html_safe
+    @flash_team_name = flash_team_name
+    @task_member = task_member
+    @task_name = task_name
+    @project_overview = project_overview
+    @task_description = task_description
+    @all_inputs = all_inputs
+    @input_link = input_link
+    @outputs = outputs
+    @output_description = output_description
+    @task_duration = task_duration
+    @url = url
+              
+    mail(:from => sender_email, :bcc => recipient_email, :subject => subject)
+  end
   
   def send_task_acceptance_email(sender_email, recipient_email, subject, flash_team_name, task_member, task_name, project_overview, task_description, all_inputs, input_link, outputs, output_description, task_duration, foundry_url)
   

--- a/app/views/flash_teams/_starter_task_content.html.erb
+++ b/app/views/flash_teams/_starter_task_content.html.erb
@@ -130,7 +130,10 @@
 						<div class="span11">
 
 
-							<p> To complete the starter task, click on the following URL. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork and signing in to Foundry via the link sent to you via email. </p>
+							<p> To complete the starter task, click on the URL below. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork, signing in to Foundry via the link sent to you via email and clicking the start button on your task. </p>
+
+							<p>If you have any questions as you working on the task, please send us an email at stanfordhci.odesk@gmail.com.</p>
+
 							<p>URL placeholder (URL will be generated once this form is submitted) </p>
 					<p>
 						Best, <br />

--- a/app/views/flash_teams/_starter_task_content.html.erb
+++ b/app/views/flash_teams/_starter_task_content.html.erb
@@ -8,7 +8,7 @@
   			<div>
 		  	  	<div class="row-fluid">
 		  	  		<div class="span7">
-		  	  			<p class="mb" style="font-size:18px;"><i class="fa fa-angle-right"></i> Task Available Email </p>
+		  	  			<p class="mb" style="font-size:18px;"><i class="fa fa-angle-right"></i> Starter Task Email </p>
 					</div>
 					
 					<div class="span5">
@@ -43,19 +43,27 @@
 					<div class="row-fluid span12">
 						  <div class="span11">
 							  <p>
-								This is an email from the Stanford HCI Group notifying you that a job requiring a 
+								This is an email from the Stanford HCI Group regarding your interest in joining our 
 
 								<select name="task_member" required="required">
 									<option value="">-- SELECT MEMBER ROLE --</option>
 									<%@task_members.each do |task_member|%>
 										<%=options_for_select([[task_member['role'], task_member['role']]])%>
+										
 									<%end%>
 								</select> 
 								
-								for the <%=text_field_tag(:task_name,  @flash_team_event['title'], :class => 'span4') %> task for the <em><%=@flash_team_json['title']%></em> project 
+								panel. We are excited to hear you are interested in working with us!
+								<!-- for the <%=text_field_tag(:task_name,  @flash_team_event['title'], :class => 'span4') %> task for the <em><%=@flash_team_json['title']%></em> project 
 								has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within 
-								the specified deadline.
-							</p>	
+								the specified deadline. -->
+							</p>
+							<p>
+							In order to join the panel, we request that you complete a starter task to make sure that you have the skills and experiences needed to complete the types of tasks that will be made available. Once you complete the starter task, we will review your deliverable and make a decision. If you are invited to join the panel, you will receive a link to access the panel on boarding and confirm your membership. At that point, you will start receiving jobs as they become available.
+							</p>
+							<p>
+							The starter task is designed to also give you exposure and experience with Foundry, our workflow management and collaboration platform. The information about the project, your starter task and compensation for your time is below. Once you accept the task, you will be taken to Foundry, which will provide you with more information.	
+							</p>
 						</div>
 					</div>
                       
@@ -105,11 +113,25 @@
 							</p>
 						</div>
 					</div>
+
+					<div class="row-fluid span12">
+						<div class="span11">
+							<p>
+								<% compensation_content = "You will be paid for " + @task_duration + " of your time. Please make sure to track your time on Upwork in order to get paid." 
+								%>
+
+								<%=label_tag(:compensation_info, "Compensation & Hiring Information (optional):") %>
+								<%= text_area_tag(:compensation_info, compensation_content, :class => 'span12', :rows =>3) %>
+							</p>
+						</div>
+					</div>
 		                              
 		            <div class="row-fluid span12">
-						<div class="span11">							  
-													<p> If you are available and ready to start working on this task within 30 minutes of being hired, click on the following URL. On clicking this URL, you will be redirected to a page with realtime updates about your hiring status. If you are hired, you will have to confirm your email address (make sure to use the same email address), following which you will be granted access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on oDesk and signing in to Foundry via the link sent to you. If you are not hired, you will be notified for future opportunities.</p>
-							<p><p> URL placeholder (URL will be generated once this form is submitted) </p>
+						<div class="span11">
+
+
+							<p> To complete the starter task, click on the following URL. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork and signing in to Foundry via the link sent to you via email. </p>
+							<p>URL placeholder (URL will be generated once this form is submitted) </p>
 					<p>
 						Best, <br />
 						Stanford HCI Research Team

--- a/app/views/flash_teams/_starter_task_content.html.erb
+++ b/app/views/flash_teams/_starter_task_content.html.erb
@@ -1,0 +1,131 @@
+<div class="row-fluid">
+	
+	<h3><i class="fa fa-angle-right"></i> Hiring Emails</h3>
+          	
+  	<!-- INPUT MESSAGES -->
+  	<div class="row-fluid">
+  		<div id="email-form-div" class="form-panel span8">
+  			<div>
+		  	  	<div class="row-fluid">
+		  	  		<div class="span7">
+		  	  			<p class="mb" style="font-size:18px;"><i class="fa fa-angle-right"></i> Task Available Email </p>
+					</div>
+					
+					<div class="span5">
+						<p class="mb"><a id="hidePanelsLink" style="font-size:14px; float: right;" onclick="hideRightPanels()">Hide Panels</a></p>
+					</div>
+				</div> <!-- end div class row -->
+	
+          	  <%= form_tag({action: "send_starter_task", method: "post", name: "taskOverviewForm"},{:class => "hiring-email-form"}) do %>
+                      <div class="row-fluid span12">
+                          <%= label_tag(:sender_email, "From:", :class => 'span2') %>
+						  <div class="span10">
+						  	<%= text_field_tag(:sender_email, "", :placeholder => ENV['DEFAULT_EMAIL'], :class => 'span11') %>
+							</div>
+                      </div>
+                      
+                      <div class="row-fluid span12">
+                          <%= label_tag(:recipient_email, "To:", :class => 'span2') %>
+                          
+						  <div class="span10">
+						  	<%= text_area_tag(:recipient_email, "", :placeholder => "Enter recipient email addresses by selecting their emails from the panel or typing them manually (emails must be separated by a comma)", :rows =>3, :class => 'span11', :required => true ) %>
+							</div>
+						
+                      </div>
+                      
+                       <div class="row-fluid span12">
+                          <%= label_tag(:subject, "Subject:", :class => 'span2') %>
+						  <div class="span10">
+						  	<%= text_field_tag(:subject, @starter_task_email_subject, :class => 'span11', :required => true) %>
+							</div>
+                      </div>
+
+					<div class="row-fluid span12">
+						  <div class="span11">
+							  <p>
+								This is an email from the Stanford HCI Group notifying you that a job requiring a 
+
+								<select name="task_member" required="required">
+									<option value="">-- SELECT MEMBER ROLE --</option>
+									<%@task_members.each do |task_member|%>
+										<%=options_for_select([[task_member['role'], task_member['role']]])%>
+									<%end%>
+								</select> 
+								
+								for the <%=text_field_tag(:task_name,  @flash_team_event['title'], :class => 'span4') %> task for the <em><%=@flash_team_json['title']%></em> project 
+								has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within 
+								the specified deadline.
+							</p>	
+						</div>
+					</div>
+                      
+		            <div class="row-fluid span12">
+						<div class="span11">
+							<%= label_tag(:project_overview, "Project Overview:") %>
+							<%= text_area_tag(:project_overview, @flash_team_json['projectoverview'], :class => 'span12', :rows =>5, :required => true) %>
+						</div>
+					</div>
+		                              
+		            <div class="row-fluid span12">
+						<div class="span11">			
+							<%= label_tag(:task_description, "Task Description:") %>
+							<%= text_area_tag(:task_description, @flash_team_event['notes'], :class => 'span12', :rows =>5, :required => true) %>
+						</div>
+					</div>
+		                              
+		            <div class="row-fluid span12">
+						<div class="span11">				
+							<p>
+								<%= label_tag(:all_inputs, "Input(s):") %>
+								For this task, you will receive the following input(s):
+								<%= text_field_tag(:all_inputs, @flash_team_event['all_inputs'], :class => 'span6') %>. You can access the input(s) at the following link:
+								<%= text_field_tag(:input_link, "", :placeholder => "OPTIONAL: [INSERT LINK TO INPUT]", :class => 'span12') %>
+							</p>
+						</div>
+					</div>
+		                              
+		            <div class="row-fluid span12">
+						<div class="span11">
+							<p>
+								<%= label_tag(:outputs, "Deliverable(s):") %>
+								<%= text_field_tag(:outputs, @flash_team_event['outputs'], :class => 'span12') %>
+							</p>
+							<p>
+								<%=label_tag(:output_description, "Deliverable Information (optional):") %>
+								<%= text_area_tag(:output_description, "", :placeholder => "OPTIONAL: [INSERT BRIEF DESCRIPTION OF OUTPUT]", :class => 'span12', :rows =>3) %>
+							</p>
+						</div>
+					</div>
+		                              
+		            <div class="row-fluid span12">
+						<div class="span11">
+							<p>
+								<%= label_tag(:task_duration, "Task Duration:") %>
+								You will have <%= text_field_tag(:task_duration, @task_duration, :class => 'span5', :required => true)%> to finish this task.
+							</p>
+						</div>
+					</div>
+		                              
+		            <div class="row-fluid span12">
+						<div class="span11">							  
+													<p> If you are available and ready to start working on this task within 30 minutes of being hired, click on the following URL. On clicking this URL, you will be redirected to a page with realtime updates about your hiring status. If you are hired, you will have to confirm your email address (make sure to use the same email address), following which you will be granted access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on oDesk and signing in to Foundry via the link sent to you. If you are not hired, you will be notified for future opportunities.</p>
+							<p><p> URL placeholder (URL will be generated once this form is submitted) </p>
+					<p>
+						Best, <br />
+						Stanford HCI Research Team
+						<br /><br />
+					</p>
+										 
+					<%= button_tag("Send Task Available Email", :type => 'submit', :class => 'btn btn-primary') %>
+		 	 
+					</div>
+					</div>
+				<% end %>
+			</div><!-- /form-panel -->
+ 		</div><!-- /span7 -->
+  		
+  	
+ 		<%= render :partial => "task_hiring_right_sidebar" %>  
+  			
+  	</div><!-- /row -->
+</div>

--- a/app/views/flash_teams/_starter_task_email_content.html.erb
+++ b/app/views/flash_teams/_starter_task_email_content.html.erb
@@ -15,19 +15,30 @@
 				
 				<div class="row-fluid span11">
 					<p>This is an email from the Stanford HCI Group regarding your interest in joining our  <%=@task_member%> panel. We are excited to hear you are interested in working with us!</p>
+					<p>
+					In order to join the panel, we request that you complete a starter task to make sure that you have the skills and experiences needed to complete the types of tasks that will be made available. Once you complete the starter task, we will review your deliverable and make a decision. If you are invited to join the panel, you will receive a link to access the panel on boarding and confirm your membership. At that point, you will start receiving jobs as they become available.
+					</p>
+					<p>
+					The starter task is designed to also give you exposure and experience with Foundry, our workflow management and collaboration platform. The information about the project, your starter task and compensation for your time is below. Once you accept the task, you will be taken to Foundry, which will provide you with more information.	
+					</p>
 						
 						<p><b>Project overview:</b> <%= raw @project_overview %></p>
 						<p><b>Task description:</b> <%= raw @task_description %></p>
 						
 						<p>
+							<%if !@all_inputs.empty?%>
 							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@all_inputs%>. 
+							<% end %>
 						
 						<%if !@input_link.empty?%>
 							You can access the input(s) at the following link: <a href="<%=@input_link%>"><%=@input_link%></a>
-						</p>
-						<%end%>
 						
+						<%end%>
+						</p>
+						
+						<%if !@outputs.empty?%>
 						<p><b>Deliverable(s):</b> <%=@outputs%></p>
+						<% end %>
 						
 						<%if !@output_description.empty?%>
 						<p><b>Deliverable information:</b> <%=@output_description%></p>
@@ -39,10 +50,12 @@
 						<p><b>Compensation Information:</b> <%=@compensation_info%></p>
 						<%end%>
 						
-						<p> To complete the starter task, click on the following URL. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork and signing in to Foundry via the link sent to you via email. </p>
-							<p>URL placeholder (URL will be generated once this form is submitted) </p>
-							
-							<p><p> URL: <%=link_to "I accept", @url%>. </p>
+						<p> To complete the starter task, click on the URL below. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork, signing in to Foundry via the link sent to you via email and clicking the start button on your task. </p>
+
+						<p>If you have any questions as you working on the task, please send us an email at stanfordhci.odesk@gmail.com.</p>
+						<p>URL placeholder (URL will be generated once this form is submitted) </p>
+
+						<p> URL: <%=link_to "I accept", @url%>. </p>
 						<p>
 							Best, <br />
 							Stanford HCI Research Team

--- a/app/views/flash_teams/_starter_task_email_content.html.erb
+++ b/app/views/flash_teams/_starter_task_email_content.html.erb
@@ -1,0 +1,53 @@
+<div class="row-fluid">
+	
+	<h3><i class="fa fa-angle-right"></i> Task Available Email</h3>
+          	
+  	<!-- INPUT MESSAGES -->
+  	<div class="row-fluid">
+  		<div id="email-form-div" class="form-panel span12">
+  			<!-- <div class="form-panel"> -->
+  			<div>
+		  	  	<div class="row-fluid">
+		  	  		<div class="span7">
+		  	  			<p style="font-size:18px;"><i class="fa fa-angle-right"></i> A task is available! </p>
+					</div>
+				</div> <!-- end div class row -->
+				
+				<div class="row-fluid span11">
+					<p>This is an email from the Stanford HCI Group notifying you that a job requiring a <%=@task_member%> for the <%=@task_name%> task for the <%=@flash_team_name%> project has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within the specified deadline.</p>
+						
+						<p><b>Project overview:</b> <%= raw @project_overview %></p>
+						<p><b>Task description:</b> <%= raw @task_description %></p>
+						
+						<p>
+							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@all_inputs%>. 
+						
+						<%if !@input_link.empty?%>
+							You can access the input(s) at the following link: <a href="<%=@input_link%>"><%=@input_link%></a>
+						</p>
+						<%end%>
+						
+						<p><b>Deliverable(s):</b> <%=@outputs%></p>
+						
+						<%if !@output_description.empty?%>
+						<p><b>Deliverable information:</b> <%=@output_description%></p>
+						<%end%>
+						
+						<p><b>Deadline:</b>You will have <%=@task_duration%> to finish this task </p>
+						
+						
+						<p> If you are available and ready to start working on this task within 30 minutes of being hired, click on the following URL. On clicking this URL, you will be redirected to a page with realtime updates about your hiring status. If you are hired, you will have to confirm your email address (make sure to use the same email address), following which you will be granted access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on oDesk and signing in to Foundry via the link sent to you. If you are not hired, you will be notified for future opportunities.</p>
+							<p><p> URL: <%=link_to "I accept", @url%>. </p>
+						<p>
+							Best, <br />
+							Stanford HCI Research Team
+						</p>
+					
+				</div>
+	
+          	  
+			</div><!-- /form-panel -->
+		</div><!-- /span7 -->
+  		  			
+  	</div><!-- /row -->
+</div>

--- a/app/views/flash_teams/_starter_task_email_content.html.erb
+++ b/app/views/flash_teams/_starter_task_email_content.html.erb
@@ -9,12 +9,12 @@
   			<div>
 		  	  	<div class="row-fluid">
 		  	  		<div class="span7">
-		  	  			<p style="font-size:18px;"><i class="fa fa-angle-right"></i> A task is available! </p>
+		  	  			<p style="font-size:18px;"><i class="fa fa-angle-right"></i> Starter Task Information! </p>
 					</div>
 				</div> <!-- end div class row -->
 				
 				<div class="row-fluid span11">
-					<p>This is an email from the Stanford HCI Group notifying you that a job requiring a <%=@task_member%> for the <%=@task_name%> task for the <%=@flash_team_name%> project has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within the specified deadline.</p>
+					<p>This is an email from the Stanford HCI Group regarding your interest in joining our  <%=@task_member%> panel. We are excited to hear you are interested in working with us!</p>
 						
 						<p><b>Project overview:</b> <%= raw @project_overview %></p>
 						<p><b>Task description:</b> <%= raw @task_description %></p>
@@ -35,8 +35,13 @@
 						
 						<p><b>Deadline:</b>You will have <%=@task_duration%> to finish this task </p>
 						
+						<%if !@compensation_info.empty?%>
+						<p><b>Compensation Information:</b> <%=@compensation_info%></p>
+						<%end%>
 						
-						<p> If you are available and ready to start working on this task within 30 minutes of being hired, click on the following URL. On clicking this URL, you will be redirected to a page with realtime updates about your hiring status. If you are hired, you will have to confirm your email address (make sure to use the same email address), following which you will be granted access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on oDesk and signing in to Foundry via the link sent to you. If you are not hired, you will be notified for future opportunities.</p>
+						<p> To complete the starter task, click on the following URL. On clicking this URL, you will be redirected to a page with information about the task. You should then click on 'Accept' and confirm your email address (make sure to use the same email address), which will grant you access to the <%=@task_name%> task on Foundry. Further, you must confirm that you have started working by accepting the contract on Upwork and signing in to Foundry via the link sent to you via email. </p>
+							<p>URL placeholder (URL will be generated once this form is submitted) </p>
+							
 							<p><p> URL: <%=link_to "I accept", @url%>. </p>
 						<p>
 							Best, <br />

--- a/app/views/flash_teams/_task_available_email_content.html.erb
+++ b/app/views/flash_teams/_task_available_email_content.html.erb
@@ -15,6 +15,13 @@
 				
 				<div class="row-fluid span11">
 					<p>This is an email from the Stanford HCI Group notifying you that a job requiring a <%=@task_member%> for the <%=@task_name%> task for the <%=@flash_team_name%> project has become available. Please take a look at the following job description to see if you are interested in and qualified to complete this task within the specified deadline.</p>
+
+					<p>
+					In order to join the panel, we request that you complete a starter task to make sure that you have the skills and experiences needed to complete the types of tasks that will be made available. Once you complete the starter task, we will review your deliverable and make a decision. If you are invited to join the panel, you will receive a link to access the panel on boarding and confirm your membership. At that point, you will start receiving jobs as they become available.
+					</p>
+					<p>
+					The starter task is designed to also give you exposure and experience with Foundry, our workflow management and collaboration platform. The information about the project, your starter task and compensation for your time is below. Once you accept the task, you will be taken to Foundry, which will provide you with more information.	
+					</p>
 						
 						<p><b>Project overview:</b> <%= raw @project_overview %></p>
 						<p><b>Task description:</b> <%= raw @task_description %></p>

--- a/app/views/flash_teams/_task_hiring_email.html.erb
+++ b/app/views/flash_teams/_task_hiring_email.html.erb
@@ -77,7 +77,12 @@
                       </a>
                       <ul class="sub">
                           <li class=<%=@task_avail_active%>><%=link_to "Task Available", controller: "flash_teams", action: "hire_form"%> </li>
+
                           <li class=<%=@list_queue_active%>><%=link_to "Hiring queue", @url1%> </li>
+                      </ul>
+
+                      <ul class="sub">
+                          <li class=<%=@starter_task_active%>><%=link_to "Starter Task", controller: "flash_teams", action: "starter_task"%> </li>
                       </ul>
                   </li>
 

--- a/app/views/flash_teams/_task_hiring_right_sidebar.html.erb
+++ b/app/views/flash_teams/_task_hiring_right_sidebar.html.erb
@@ -40,14 +40,16 @@
 			<table class="table table-bordered" style="word-break: break-word;">
 			    <thead>
 					<th class="span1"><i class="icon-ok"></i></th>
+					<th class="span1">Id</th>
 					<th class="span3">Name</th>
-					<th class="span5">Email</th>
-					<th class="span2">Panel</th>
+					<th class="span4">Email</th>
+					<th class="span3">Panel</th>
 			    </thead>
 			    <tbody>
 					<% @workers.each do |worker| %>
 					    <tr>
 					        <td><%= check_box_tag("workers[#{worker.id}]", worker.id) %></td>
+					        <td><%= worker.id %></td>
 					        <td><%= worker.name %></td>
 					        <td><%= worker.email %></td>
 					        <td><%= worker.panel %></td>

--- a/app/views/flash_teams/send_starter_task.html.erb
+++ b/app/views/flash_teams/send_starter_task.html.erb
@@ -1,0 +1,2 @@
+<%= render partial: "starter_task_email_content", layout: "task_hiring_email" %>
+<%# link_to "I accept", @url%>. 

--- a/app/views/flash_teams/starter_task.html.erb
+++ b/app/views/flash_teams/starter_task.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "starter_task_content", layout: "task_hiring_email" %>

--- a/app/views/landings/_starter_task_acceptance_email_content_landing.html.erb
+++ b/app/views/landings/_starter_task_acceptance_email_content_landing.html.erb
@@ -1,11 +1,13 @@
 <div class="row-fluid">
 
-	<h3><i class="fa fa-angle-right"></i> Task Available</h3>
+	<h3><i class="fa fa-angle-right"></i> Starter Task Information</h3>
           	
   	<div class="row-fluid">
   		<div class="form-panel span12">
   			<p>
-  				<b>Congratulations!  You are at No. 1 position in the hiring queue for the <%=@task_member%> role to work on the <%=@task_name%> task as part of the <%=@flash_team_name%> project. </b>
+  				<b>We are excited to hear you are interested in joining the <%=@task_member%> panel! <!-- to work on the <%=@task_name%> task as part of the <%=@flash_team_name%> project. --> </b>
+  				</p>
+  			<p><em>Please read the following information carefully as it contains important information for completing the starter task. </em>
   			</p>
 
   		</div>
@@ -14,12 +16,16 @@
 
   	<div class="row-fluid">
   		<div class="form-panel form-panel-instructions span12">
-  			<p>
-  				<em>Please read the following information carefully.</em> You should complete the entire registration process (including confirming your email account) within the next <%=@wait_time%> to retain your position in the hiring queue. However, to reinforce again, you must read the following information very carefully-the originally allocated 10 minutes is a lot of time. 
+  			<!-- <p>
+  				<em>Please read the following information carefully.</em> If at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. 
+  			</p> -->
 
-						<br /><br />
-						<em>Please do not close this page;</em> this page will refresh every 60 seconds with the remaining time to help you pace yourself. Moreover, if at any time you would like to decline this position and be removed from the hiring queue (only for this position), we ask that you <%=link_to "click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>. 
-  			</p>
+  			<p>
+			In order to join the panel, we request that you complete a starter task to make sure that you have the skills and experiences needed to complete the types of tasks that will be made available. Once you complete the starter task, we will review your deliverable and make a decision. If you are invited to join the panel, you will receive a link to access the panel on boarding and confirm your membership. At that point, you will start receiving jobs as they become available.
+			</p>
+			<p>
+			The starter task is designed to also give you exposure and experience with Foundry, our workflow management and collaboration platform. The information about the project, your starter task and compensation for your time is below. Once you accept the task, you will be taken to Foundry, which will provide you with more information.	
+			</p>
   		</div>
   	</div>
   	<div class="row-fluid">
@@ -48,21 +54,25 @@
 					</p> -->
 
 					<p> 
-						As stated in the job description, you will have <b><em><%=@task_duration%></em></b> to complete this task and must start working within 30 minutes from now. Please make sure to track your working hours on oDesk. For your reference, we have included the job description below:
+						As stated in the job description, you will have <b><em><%=@task_duration%></em></b> to complete this task. Please make sure to track your working hours on Upwork and to start your task on Foundry. Additional information regarding compensation can be found in the email describing the starter task. For your reference, we have included the job description below:
 					</p>
 						
 						<p><b>Project overview:</b> <%= raw @project_overview%></p>
 						<p><b>Task description:</b> <%= raw @task_description%></p>
 						
 						<p>
-							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@inputs%>. 
+						<%if !@inputs.empty?%>
+							<b>Input(s):</b> For this task, you will receive the following input(s): <%=@inputs%>.
+						<% end %> 
 						
 						<%if !@input_link.nil?%>
 						You can access the input(s) at the following link: <a href="<%=@input_link%>"><%=@input_link%></a>
-						</p>
 						<%end%>
+						</p>
 						
+						<%if !@outputs.empty?%>
 						<p><b>Deliverable(s):</b> <%=@outputs%></p>
+						<% end %>
 						
 						<%if !@output_description.nil?%>
 						<p><b>Deliverable information:</b> <%=@output_description%></p>
@@ -73,12 +83,13 @@
 						</p>
 						
 						<p><%=link_to "Click here to register for this position on Foundry", @invitationLink%></p>
+
 						
 						<p>
-							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us if you have any remaining questions.
+							After you sign up, you will receive a unique link to the project, which you should use to access your task, keep track of your progress and submit your work. If you are unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us (stanfordhci.odesk@gmail.com) if you have any remaining questions.
 						</p>  
 						
-			<p>Again, if you would not like to work on this project any more, <%=link_to "Click here to give up your spot in the hiring queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%> so that others can be offered the job.</p>
+			<p>If you would not like to join the panel any more, <%=link_to "Click here", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%> to decline the starter task.</p>
 
 			
 						<p>

--- a/app/views/landings/_task_hiring_email.html.erb
+++ b/app/views/landings/_task_hiring_email.html.erb
@@ -60,8 +60,10 @@
                    
                 <% if @queuePosition == 1 %>
 
+                   <% if @starter_task != true %>
                    <h6 class="task-name">Position in Queue: No. <%=@queuePosition%></h6>
                    <h6 class="task-name">Deadline to Accept Position: <br /> <%=@wait_time%> </h6>
+                   <% end %>
                    
                    <h6 class="task-name">
                       <%= link_to("Accept this position", @invitationLink, :class => 'btn btn-success') %>
@@ -81,13 +83,24 @@
                 <% end %>
 
                  <% if @queuePosition >1 %>
+                    <% if @starter_task != true %>
+                     <h6 class="task-name">Position in Queue: No. <%=@queuePosition%></h6>
+                     <h6 class="task-name">Wait Time Remaining: <br /><%=@wait_time%> </h6>
 
-                   <h6 class="task-name">Position in Queue: No. <%=@queuePosition%></h6>
-                   <h6 class="task-name">Wait Time Remaining: <br /><%=@wait_time%> </h6>
+                     <h6 class="task-name">
+                        <%=link_to "Decline Position & Remove from Hiring Queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>
+                     </h6>
+                     <% end %> 
 
-                   <h6 class="task-name">
-                      <%=link_to "Decline Position & Remove from Hiring Queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>
-                   </h6>
+                     <% if @starter_task == true %>
+                         <h6 class="task-name">
+                          <%= link_to("Accept this position", @invitationLink, :class => 'btn btn-success') %>
+                       </h6>
+
+                       <h6 class="task-name">
+                          <%=link_to "Decline this position", @removalURL, :class => 'btn btn-default', :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%>
+                       </h6>
+                     <% end %>
                 <% end %>
               	 	     
                 

--- a/app/views/landings/view.html.erb
+++ b/app/views/landings/view.html.erb
@@ -2,8 +2,12 @@
 <%= render partial: "error" %>
 <% elsif @queuePosition==-2 %>
 <%= render partial: "error1" %>
-<% elsif @queuePosition == 1 %>
-<%= render partial: "task_acceptance_email_content_landing", layout: "task_hiring_email" %>
+<% elsif @queuePosition == 1 || @starter_task == true%>
+	<% if @starter_task == true %>
+		<%= render partial: "starter_task_acceptance_email_content_landing", layout: "task_hiring_email" %>
+	<% else %>
+		<%= render partial: "task_acceptance_email_content_landing", layout: "task_hiring_email" %>
+	<% end %>
 <% elsif @queuePosition == 0 %>
 <%= render partial: "task_rejection_email_content_landing", layout: "task_hiring_email" %>
 <% else %>

--- a/app/views/user_mailer/send_starter_task_email.html.erb
+++ b/app/views/user_mailer/send_starter_task_email.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "flash_teams/starter_task_email_content", layout: "send_task_hiring_email" %>

--- a/app/views/workers/_filter_workers.html.erb
+++ b/app/views/workers/_filter_workers.html.erb
@@ -31,6 +31,7 @@
 	<table class="table table-bordered table-striped" style="overflow: auto">
 	    <thead>
 			<th><i class="icon-ok"></i></th>
+			<th>Id</th>
 			<th>Name</th>
 			<th>Email</th>
 			<th>Skype Username</th>
@@ -50,6 +51,7 @@
 			<% @workers.each do |worker| %>
 			    <tr>
 			        <td><%= check_box_tag("workers[#{worker.id}]", worker.id) %></td>
+			        <td><%= worker.id %></td>
 			        <td><%= worker.name %></td>
 			        <td><%= worker.email %></td>
 			        <td><%= worker.skype_username %></td>

--- a/app/views/workers/_filter_workers_rightsidebar.html.erb
+++ b/app/views/workers/_filter_workers_rightsidebar.html.erb
@@ -25,15 +25,17 @@
 	<!-- <table class="table table-bordered table-striped" style="background-color: white;"> -->
 	<table class="table table-bordered" style="word-break: break-word;">
 	    <thead>
-			<th><i class="icon-ok"></i></th>
-			<th>Name</th>
-			<th>Email</th>
-			<th>Panel</th>
+			<th class="span1"><i class="icon-ok"></i></th>
+			<th class="span1">Id</th>
+			<th class="span3">Name</th>
+			<th class="span4">Email</th>
+			<th class="span3">Panel</th>
 	    </thead>
 	    <tbody>
 			<% @workers.each do |worker| %>
 			    <tr>
 			        <td><%= check_box_tag("workers[#{worker.id}]", worker.id) %></td>
+			        <td><%= worker.id %></td>
 			        <td><%= worker.name %></td>
 			        <td><%= worker.email %></td>
 			        <td><%= worker.panel %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Foundry::Application.routes.draw do
   end
 
   get '/flash_teams/:id/:event_id/hire_form' => 'flash_teams#hire_form'
+  get '/flash_teams/:id/:event_id/hire_form/starter_task' => 'flash_teams#starter_task'
 
   get '/flash_teams/:id/:event_id/hire_form/task_rejection' => 'flash_teams#task_rejection'
   get '/flash_teams/:id/:event_id/hire_form/task_acceptance' => 'flash_teams#task_acceptance'
@@ -99,6 +100,7 @@ Foundry::Application.routes.draw do
 get '/flash_teams/:id/:event_id/listQueueForm' => 'flash_teams#listQueueForm'
 
   get '/landings/:id/:event_id/remove' => 'landings#remove'
+  post '/flash_teams/:id/:event_id/hire_form/send_starter_task' => 'flash_teams#send_starter_task'
   post '/flash_teams/:id/:event_id/hire_form/send_task_acceptance' => 'flash_teams#send_task_acceptance'
   post '/flash_teams/:id/:event_id/hire_form/send_task_rejection' => 'flash_teams#send_task_rejection'
   post '/flash_teams/:id/:event_id/hire_form/send_task_available' => 'flash_teams#send_task_available'


### PR DESCRIPTION
This PR adds the starter task feature so we can send different emails for starter tasks (compared to the task available emails). The landings controller and view page have also been updated to support the starter task content. 