### PR TITLE
added a options button to task modal and added a way to create a new …

### DIFF
--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -28,7 +28,8 @@ function eventMousedown(task2idNum) {
 
        var modal_footer =  '<a href=' + eventObj['gdrive'][1] +' class="btn btn-primary" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logTaskOverviewGDriveBtnClick(' + task_id  + ')">Deliverables</a>' + 
        '<button class="btn " id="hire-task" style="float :left " onclick="hireForm('+task2idNum+')">Hire</button>' +
-       '<button class="btn " id="duplicate-task" style="float :left " onclick="duplicateEvent('+task2idNum+', true)">Duplicate</button>' +
+       //'<button class="btn " id="duplicate-task" style="float :left " onclick="duplicateEvent('+task2idNum+', true)">Duplicate</button>' +
+       createOptionsButton(task2idNum) + 
        '<button class="btn " id="start-end-task" style="float :right " onclick="confirm_show_docs('+task2idNum+')">Start</button>'+
        '<button class="btn " id="pause-resume-task" style="float :right " onclick="pauseTask('+task2idNum+')">Take a Break</button>'+
        '<button class="btn" id="edit-save-task" onclick="editTaskOverview(true,'+task2idNum+')">Edit</button>' +

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -597,6 +597,30 @@ function formatModalTime(timeInMins){
     return timeStr;
 }
 
+function createOptionsButton(groupNum){
+
+    var ev_index = getEventJSONIndex(groupNum);
+    var ev_title = flashTeamsJSON["events"][ev_index].title; 
+
+    var optionsBtn = '<div class="btn-group dropup">'
+                + '<a class="btn dropdown-toggle" data-toggle="dropdown" href="#">'
+                    + 'Options'
+                    + '<span class="caret"></span>'
+                + '</a>'
+                + '<ul class="dropdown-menu">'
+                    + '<li><a tabindex="-1" href="#" id="duplicate-task" onclick="duplicateEvent('+ groupNum +', true)">Duplicate</a></li>';
+           if(flashTeamsJSON.folder != undefined){         
+                optionsBtn += '<li><a tabindex="-1" href="#" id="new-gdrive-proj-folder" '
+                    + 'onclick="createTaskFolder(\'' + ev_title + ' - ' + groupNum + '\', ' + ev_index + ', \'' + flashTeamsJSON.folder[0] + '\')"'
+                    + '>New GDrive Folder</a></li>';
+            }
+
+        optionsBtn += '</ul>'
+                    + '</div>';
+    
+    return optionsBtn;
+}
+
 function saveTaskOverview(groupNum){
 	var task_index = getEventJSONIndex(groupNum); 
 	var ev = flashTeamsJSON["events"][task_index];


### PR DESCRIPTION
…google drive folder for an event

There is now an options button on the task modal that has a dropup menu that has 1) duplicate event; 2) add a new gdrive folder, which creates a new google drive folder for the task and leaves the original folder in the project folder. The new google drive folder that is created for the task contains the original name followed by the groupnum for the event. If you rename the task, it updates the google drive folder accordingly. If the project hasn't been started (e.g., the google drive project folder doesn't exist), the add a new google drive folder option does not appear in the dropup menu. 

![image](https://cloud.githubusercontent.com/assets/5275384/8363460/e035f7e4-1b33-11e5-8057-d885fbc7652b.png)
