### PR TITLE
slack integration for our three summer orgs

### DIFF
--- a/app/assets/javascripts/authoring/taskStatus.js
+++ b/app/assets/javascripts/authoring/taskStatus.js
@@ -534,7 +534,8 @@ var completeTask = function(groupNum){
 var postToSlack = function(event, update) {
     var title = event['title'];
     var user = chat_name;
-    var teamUrl = 'http://foundry-app.herokuapp.com/flash_teams/'+flash_team_id+'/'
+    var teamUrl = defaultUrl + '/flash_teams/'+flash_team_id+'/edit';
+    //var teamUrl = 'http://foundry-app.herokuapp.com/flash_teams/'+flash_team_id+'/';
 
     // HACK HACK HACK for summer deployment. 
     //Eventually teams need to have a place they can store the private URLs
@@ -555,15 +556,22 @@ var postToSlack = function(event, update) {
         private_slack_url = slackPrivateUrls['truestory'];
     }
 
+    var defaultMsg = notification_group + ': ' + user + ' has ' + update + ' *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.>';
+
     var slackMsg = "";
+
     if (update == "completed") {
-        slackMsg = notification_group + ': ' + user + ' has completed *' + title + '* on Foundry. <' + teamUrl + '|See the submission on Foundry.> Congratulate \'em! The next task is ready to start!';
+        //slackMsg = notification_group + ': ' + user + ' has completed *' + title + '* on Foundry. <' + teamUrl + '|See the submission on Foundry.> Congratulate \'em! The next task is ready to start!';
+        slackMsg = defaultMsg + ' Congratulate \'em! The next task is ready to start!';
     } else if (update == "started") {
-        slackMsg = notification_group + ': ' + user + ' has started *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Wish \'em luck!';
+        //slackMsg = notification_group + ': ' + user + ' has started *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Wish \'em luck!';
+        slackMsg = defaultMsg + ' Wish \'em luck!';
     } else if (update == "paused") {
-        slackMsg = notification_group + ': ' + user + ' has paused *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Let \'em know you hope to see them back soon!';
+        //slackMsg = notification_group + ': ' + user + ' has paused *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Let \'em know you hope to see them back soon!';
+        slackMsg = defaultMsg + ' Let \'em know you hope to see them back soon!';
     } else if (update == "resumed") {
-        slackMsg = notification_group + ': ' + user + ' has resumed *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Issue a hearty \'Welcome back\'!';
+        //slackMsg = notification_group + ': ' + user + ' has resumed *' + title + '* on Foundry. <' + teamUrl + '|See the task description on Foundry.> Issue a hearty \'Welcome back\'!';
+        slackMsg = defaultMsg +  ' Issue a hearty \'Welcome back\'!';
     }
 
     var payload = 'payload={\"channel\": \"#flashteams-foundry\", \"username\": \"Foundry\", \"text\": \"' + slackMsg + '\", \"icon_emoji\": \":shipit:\", \"link_names\": 1}';

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -186,6 +186,7 @@ end
 			
   	else #else it is in worker view 
     	@flash_team = FlashTeam.find(params[:id])
+      session[:uniq] = params[:uniq]
     end 
     
 	#note: member info is stored in status json in flash_teams_json

--- a/app/controllers/flash_teams_controller.rb
+++ b/app/controllers/flash_teams_controller.rb
@@ -162,15 +162,19 @@ end
  
   def edit
   
-  	session.delete(:return_to)
+  session.delete(:return_to)
 	session[:return_to] ||= request.original_url
 	  
   if !params.has_key?("uniq") #if in author view
-	  	if session[:user].nil? 
-			@user = nil 
-			@title = "Invalid User ID"
-			@flash_team = nil
-			redirect_to(welcome_index_path) and return		
+    if session[:user].nil? 
+       if !session[:uniq].nil?
+        redirect_to :controller => 'flash_teams', :action => 'edit', :id => params[:id], :uniq => session[:uniq] and return
+			 else
+        @user = nil 
+  			@title = "Invalid User ID"
+  			@flash_team = nil
+  			redirect_to(welcome_index_path) and return
+       end		
 		else 
 			@flash_team = FlashTeam.find(params[:id])
 			
@@ -612,7 +616,6 @@ end
    		@task_name = params[:task_name]
    		@project_overview = params[:project_overview]
    		@task_description = params[:task_description]
-   		
    		
    		@all_inputs = params[:all_inputs]
    		@input_link = params[:input_link]

--- a/app/views/flash_teams/_globals.html.erb
+++ b/app/views/flash_teams/_globals.html.erb
@@ -17,4 +17,11 @@ var timeline_interval = '<%=ENV['TIMELINE_INTERVAL']%>';
 
 var defaultEmail = '<%=ENV['DEFAULT_EMAIL']%>';
 
+var slackPrivateUrls = {
+	'stanfordhcigfx': '<%=ENV['SLACK_URL_STANFORDHCIGFX']%>',
+	'truestory': '<%=ENV['SLACK_URL_TRAUMA']%>',
+	'accenture': '<%=ENV['SLACK_URL_ACCENTURE']%>',
+	'trauma': '<%=ENV['SLACK_URL_TRUESTORY']%>'
+}
+
 </script>

--- a/app/views/flash_teams/_globals.html.erb
+++ b/app/views/flash_teams/_globals.html.erb
@@ -17,6 +17,8 @@ var timeline_interval = '<%=ENV['TIMELINE_INTERVAL']%>';
 
 var defaultEmail = '<%=ENV['DEFAULT_EMAIL']%>';
 
+var defaultUrl = '<%=ENV['DEFAULT_URL']%>';
+
 var slackPrivateUrls = {
 	'stanfordhcigfx': '<%=ENV['SLACK_URL_STANFORDHCIGFX']%>',
 	'truestory': '<%=ENV['SLACK_URL_TRAUMA']%>',


### PR DESCRIPTION
Please test and merge! We're moving team communication into Slack so that there's better coordination, but we want to keep mental models in sync with what's going on in Foundry.

I couldn't test with the live teams since that requires being hosted on foundry-app.herokuapp.com. (We only post to those Slack channels when the team ID matches.) So we'll need to do a little live testing once deployed to make sure the non-#flashteams channel integration works.

@dretelny @ato1120 @negarrahmati @tdoshi 