### PR TITLE
Remove regular polling (Suggestion #1) and clean up redundant code

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -7,12 +7,6 @@ var json_transaction_id = 0;
 var poll_interval = 50000; // 20 seconds
 var poll_interval_id;
 
-//var task_timer_interval = 1000; // "normal" speed is 60000. If 1000 : each second is a minute on timeline.
-//var timeline_interval = 10000; // "normal" speed timer is 30 minutes (1800000 milliseconds); fast timer is 10 seconds (10000 milliseconds)
-var fire_interval = 180; // change back to 180
-
-var numIntervals = parseFloat(timeline_interval)/parseFloat(fire_interval);
-var increment = parseFloat(50)/parseFloat(numIntervals);
 var curr_x_standard = 0;
 
 //not updated in the current version
@@ -44,35 +38,44 @@ var window_visibility_state = null;
 var window_visibility_change = null;
 
 $(document).ready(function(){
-    addCursor();
-    cursor = timeline_svg.select(".cursor");
     colorBox();
-    //console.log("THIS FUNCTION HITS");
     $("#flash_team_id").requestUpdates(true);
     $("#flash_team_id").getTeamInfo();
 });
 
-var addCursor = function(){
-    // time cursor in red
-    timeline_svg.append("line")
-        .attr("y1", 15)
-        .attr("y2", SVG_HEIGHT-50)
-        .attr("x1", 0)
-        .attr("x2", 0)
-        .attr("class", "cursor")
-        .style("stroke", "red")
-        .style("stroke-width", "2")
-        .style("display", "none");
-};
+// Start team after asking user for confirmation
+$("#flashTeamStartBtn").click(function(){
+    var bodyText = document.getElementById("confirmActionText");
+    bodyText.innerHTML = "Are you sure you want to begin running " + flashTeamsJSON["title"] + "?";
 
-var getXCoordForTime = function(t){
-    var numInt = parseInt(t / timeline_interval);
-    var remainder = t % timeline_interval;
-    var xCoordForRemainder = (remainder / timeline_interval) * 50;
-    var xCoordForMainIntervals = 50*numInt;
-    var finalX = parseFloat(xCoordForRemainder) + parseFloat(xCoordForMainIntervals);
-    return {"finalX": finalX, "numInt": numInt};
-};
+    var confirmStartTeamBtn = document.getElementById("confirmButton");
+    confirmStartTeamBtn.innerHTML = "Start the team";
+
+    $("#confirmButton").attr("class","btn btn-success");
+    var label = document.getElementById("confirmActionLabel");
+    label.innerHTML = "Start Team?";
+    $('#confirmAction').modal('show');
+
+    document.getElementById("confirmButton").onclick=function(){startFlashTeam()};
+});
+
+$("#flashTeamEndBtn").click(function(){
+    var bodyText = document.getElementById("confirmActionText");
+    updateStatus();
+    if ((live_tasks.length == 0) && (remaining_tasks.length == 0) && (delayed_tasks.length == 0)) {
+        bodyText.innerHTML = "Are you sure you want to end " + flashTeamsJSON["title"] + "?";
+    } else {
+        bodyText.innerHTML = flashTeamsJSON["title"] + " is still in progress!  Are you sure you want to end the team?";
+    }
+    var confirmEndTeamBtn = document.getElementById("confirmButton");
+    confirmEndTeamBtn.innerHTML = "End the team";
+    $("#confirmButton").attr("class","btn btn-danger");
+    var label = document.getElementById("confirmActionLabel");
+    label.innerHTML = "End Team?";
+    $('#confirmAction').modal('show');
+
+    document.getElementById("confirmButton").onclick=function(){endTeam()};
+});
 
 function removeColabBtns(){
    var events = flashTeamsJSON["events"];
@@ -93,30 +96,13 @@ function hideAllConfigIcons(bHide){
 
 function removeHandoffBtns(){
     var events = flashTeamsJSON["events"];
-   for (var i = 0; i < events.length; i++){
+    for (var i = 0; i < events.length; i++){
         var eventObj = events[i];
         var groupNum = eventObj["id"];
         var task_g = getTaskGFromGroupNum(groupNum);
         task_g.selectAll(".handoff_btn").attr("display","none");
     }
-
 };
-
-$("#flashTeamStartBtn").click(function(){
-    var bodyText = document.getElementById("confirmActionText");
-    //updateStatus();
-    bodyText.innerHTML = "Are you sure you want to begin running " + flashTeamsJSON["title"] + "?";
-
-    var confirmStartTeamBtn = document.getElementById("confirmButton");
-    confirmStartTeamBtn.innerHTML = "Start the team";
-
-    $("#confirmButton").attr("class","btn btn-success");
-    var label = document.getElementById("confirmActionLabel");
-    label.innerHTML = "Start Team?";
-    $('#confirmAction').modal('show');
-
-    document.getElementById("confirmButton").onclick=function(){startFlashTeam()};
-});
 
 function disableTeamEditing() {
     updateInteractionsPopovers(); //update interaction popovers to read only mode
@@ -131,7 +117,6 @@ function disableTeamEditing() {
     $(selector).hide();
 
     hideAllConfigIcons(true);
-
 }
 
 function enableTeamEditing() {
@@ -151,7 +136,6 @@ function enableTeamEditing() {
 
 function startFlashTeam() {
     $('#confirmAction').modal('hide');
-    // view changes
     $("#flashTeamStartBtn").attr("disabled", "disabled");
     $("#flashTeamStartBtn").css('display','none');
     $("#flashTeamEndBtn").css('display','');
@@ -160,7 +144,6 @@ function startFlashTeam() {
 
     $("div#search-events-container").css('display','none');
     $("div#project-status-container").css('display','');
-    //$("a#gFolder.button").css('visibility','visible');
     $("div#chat-box-container").css('display','');
     $("#flashTeamTitle").css('display','none');
 
@@ -172,21 +155,12 @@ function startFlashTeam() {
     save_tasksAfter_json();
 
     startTeam(true);
-
-    //save dependencyAPI.getEventsAfter(task_id, true) for each event in the json.
-    //This is used for the notification emails.
-
-    //addAllFolders();
-    //googleDriveLink();
 }
 
-
 function endTeam() {
-    //console.log("TEAM ENDED");
     $('#confirmAction').modal('hide');
     logActivity("endTeam()",'End Team', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
     updateStatus(false);
-    stopCursor();
     stopProjectStatus();
     stopPolling();
     stopTrackingTasks();
@@ -196,53 +170,21 @@ function endTeam() {
     $("#projectStatusText").toggleClass('projectStatusText-inactive', false);
 }
 
-
 //save dependencyAPI.getEventsAfter(task_id, true) for each event in the json.
 //This is used for the notification emails.
 function save_tasksAfter_json(){
     var events_after = [];
-
     for(var i =0;i<  flashTeamsJSON["events"].length; i++){
         var id = parseInt(flashTeamsJSON["events"][i]["id"]);
         flashTeamsJSON["events"][i]["events_after"] = dependencyAPI.getEventsAfter(id, true);
-
     }
-
-
 }
 
-
-//Asks user to confirm that they want to end the team
-$("#flashTeamEndBtn").click(function(){
-    var bodyText = document.getElementById("confirmActionText");
-    updateStatus();
-    if ((live_tasks.length == 0) && (remaining_tasks.length == 0) && (delayed_tasks.length == 0)) {
-        bodyText.innerHTML = "Are you sure you want to end " + flashTeamsJSON["title"] + "?";
-    } else {
-        //console.log("ENDED TEAM EARLY");
-        //var progressRemaining = Math.round(100 - curr_status_width);
-        bodyText.innerHTML = flashTeamsJSON["title"] + " is still in progress!  Are you sure you want to end the team?";
-    }
-    var confirmEndTeamBtn = document.getElementById("confirmButton");
-    confirmEndTeamBtn.innerHTML = "End the team";
-    $("#confirmButton").attr("class","btn btn-danger");
-    var label = document.getElementById("confirmActionLabel");
-    label.innerHTML = "End Team?";
-    $('#confirmAction').modal('show');
-
-    document.getElementById("confirmButton").onclick=function(){endTeam()};
-
-
-});
-
-
 function stopPolling() {
-    //console.log("STOPPED POLLING");
     window.clearInterval(poll_interval_id);
 };
 
 function stopTrackingTasks() {
-    //console.log("STOPPED TRACKING TASKS");
     window.clearInterval(tracking_tasks_interval_id);
 };
 
@@ -266,7 +208,6 @@ if(flashTeamsJSON) {
     entryManager = new EntryManager(flashTeamsJSON);
 }
 
-
 function renderFlashTeamsJSON(data, firstTime) {
     // firstTime will also be true in the case that flashTeamEndedorStarted, so
     // we make sure that it is false (i.e. true firstTime, upon page reload for user
@@ -278,43 +219,16 @@ function renderFlashTeamsJSON(data, firstTime) {
         renderProjectOverview(); //note: not sure if this goes here, depends on who sees the project overview (e.g., user and/or requester)
     }
 
-    //console.log("inside render everything");
-    //console.log("THIS IS THE DATA", data);
-
-    //get user name and user role for the chat
-    if(data == null){
-        // if(firstTime){
-        //     renderChatbox();
-        //     renderProjectOverview();
-        //     //console.log("DATA NULL & FIRST TIME - RETURNING BEFORE LOAD");
-        // }
-        //console.log("DATA NULL - RETURNING BEFORE LOAD");
-        // will only be run way at the beginning before any members or events are added
-        // will only run in requester's page, because on members' pages, members array
-        // length will be greater than zero
-        // if (flashTeamsJSON.events.length == 0 && flashTeamsJSON.members.length == 0){
-        //     console.log("CREATED A FOLDER!!!!!!!!");
-        //     createNewFolder(flashTeamsJSON["title"]); // gdrive
-        // }
-        return; // status not set yet
-    }
-
-
     // Using transaction ID to avoid updatin client which is already updated.
-    //console.log("global " + json_transaction_id)
     var currentTransactionID = json_transaction_id || 0
-    //console.log("current " + currentTransactionID)
     var givenTransactionID = data.json_transaction_id || 1
-    //console.log("given " + givenTransactionID)
     if(currentTransactionID >= givenTransactionID) return;
-    //console.log("Rendering...")
     json_transaction_id = givenTransactionID
 
     loadedStatus = data;
 
     in_progress = loadedStatus.flash_team_in_progress;
     flashTeamsJSON = loadedStatus.flash_teams_json;
-
 
     // initialize the entry manager after flashTeamsJSON has been loaded
     window.entryManager = new window.EntryManager(flashTeamsJSON);
@@ -329,23 +243,18 @@ function renderFlashTeamsJSON(data, firstTime) {
         //renderProjectOverview(); //commented this out because we now always call setCurrentMember() in case changes are made during project
     }
 
-
     // is this the user, and has he/she loaded the page
     // before the team started
     // is_user && firstTime && in_progress would be the case
     // where the user loads the page for the first time after
     // the team has started
-    if(isUser) {
-        // user loaded page before team started
+    if(isUser) { // user loaded page before team started
         if (firstTime && !in_progress)
             user_loaded_before_team_start = true;
     }
 
-
     colorBox();
     if(in_progress){
-
-        //console.log("flash team in progress");
         $("#flashTeamStartBtn").attr("disabled", "disabled");
         $("#flashTeamStartBtn").css('display','none'); //not sure if this is necessary since it's above
         $("#flashTeamEndBtn").css('display',''); //not sure if this is necessary since it's above
@@ -380,34 +289,13 @@ function renderFlashTeamsJSON(data, firstTime) {
         else if(!flashTeamsJSON["paused"]){
             disableTeamEditing();
         }
-
-       /* //show the documentation of the previous task for the workers and the PCs.
-        if (isUser || memberType == "pc"){
-            show_previous_doc();
-            //updateStatus();
-        }*/
-
-        //startTeam(firstTime);
-
-
-
     } else {
-        //console.log("flash team not in progress");
-
         if(flashTeamsJSON["startTime"] == undefined){
-
-            //console.log("NO START TIME!");
             updateOriginalStatus();
         }
 
-        // if (flashTeamsJSON.events.length == 0 && flashTeamsJSON.members.length == 0){
-        //     console.log("CREATED A FOLDER!!!!!!!!");
-        //     createNewFolder(flashTeamsJSON["title"]); // gdrive
-        // }
-
         if(!flashTeamsJSON)
             return;
-
 
         loadData();
 
@@ -419,45 +307,27 @@ function renderFlashTeamsJSON(data, firstTime) {
             renderMembersRequester();
         }
     }
-
 }
 
 // firstTime=true means page is reloaded
 function renderEverything(data, firstTime) {
     renderFlashTeamsJSON(data, firstTime);
-
     if(firstTime) {
         logActivity("renderEverything(firstTime)",'Render Everything - First Time', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
         poll_interval_id = poll();
-        //console.log('in firstTime renderEverything');
         initTimer();
         listenForVisibilityChange();
     }
-
-
 }
-
-// render events to show timer changes
-// TODO rework to draw timers only
-// function initTimer() {
-//     setInterval(function(){
-//         //drawEvents(true);
-//         //drawStartedEvents();
-//         drawStartedEvTimers();
-//         console.log('initTimer calling drawStartedEvTimers');
-//     }, 5000)
-// }
 
 function initTimer() {
      setTimeout(function(){
         try {
-            //drawStartedEvTimers();
             drawStartedEvents();
         } catch (e) {
             console.log(e);
         }
         initTimer();
-        
      }, 5000)
  }
 
@@ -521,44 +391,31 @@ var renderChatbox = function(){
 	   // when current_user is the author it won't have a uniq id so need to check for current_user == 'Author' instead
 	   if(chat_role == 'Author'){
 		   current_user = 'Author';
-		   //console.log ("CURRENT USER AUTHOR: " + current_user);
-
 	   }
 
        if (chat_role == "" || chat_role == null){
-         uniq_u2 = data["uniq"];
-
+        uniq_u2 = data["uniq"];
 
          flash_team_members = flashTeamsJSON["members"];
-         //console.log(flash_team_members[0].uniq);
          for(var i=0;i<flash_team_members.length;i++){
-
             if (flash_team_members[i].uniq == uniq_u2){
               chat_role = flash_team_members[i].role;
               current = i;
               current_user = flash_team_members[i];
 
-              // here there once existed a call to boldEvents
-
               trackUpcomingEvent();
             }
          }
-
        }
 
        // Set our initial online status.
-		setUserStatus(currentStatus);
+       setUserStatus(currentStatus);
 
        myDataRef.on('child_added', function(snapshot) {
-                var message = snapshot.val();
-                //console.log(snapshot);
-                //console.log(message);
-                //console.log("MESSAGE NAME: " + message["name"]);
-
-                displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
-
-                name = message.name;
-            });
+            var message = snapshot.val();
+            displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
+            name = message.name;
+        });
 
     });
 };
@@ -686,7 +543,6 @@ var flashTeamUpdated = function(){
 };
 
 var poll = function(){
-    //console.log("POLLING");
     return setInterval(function(){
         $("#flash_team_id").requestUpdates(false);
     }, poll_interval); // every 5 seconds currently
@@ -711,20 +567,12 @@ var loadStatus = function(id){
 };
 
 var loadData = function(){
-    // position cursor before getting the new task arrays
-    // because once the new task arrays are updated,
-    // trackLiveAndRemainingTasks is immediately going to
-    // operate on them, while the current cursor here is
-    // not yet where it should be in time (its behind)
     var latest_time;
     if (in_progress){
         latest_time = (new Date()).getTime();
     } else {
         latest_time = loadedStatus.latest_time; // really only useful at end
     }
-
-    //Next line is commented out after disabling the ticker
-   // cursor_details = positionCursor(flashTeamsJSON, latest_time);
 
     live_tasks = loadedStatus.live_tasks;
     paused_tasks = loadedStatus.paused_tasks;
@@ -733,17 +581,7 @@ var loadData = function(){
     drawn_blue_tasks = loadedStatus.drawn_blue_tasks;
     completed_red_tasks = loadedStatus.completed_red_tasks;
 
-
-    //load_statusBar(status_bar_timeline_interval);
-
     drawEvents(!in_progress);
-
-    /*imported popover to modal
-    if(isUser){
-        updateAllPopoversToReadOnly();
-    }
-    */
-
     drawBlueBoxes();
     drawRedBoxes();
     drawDelayedTasks();
@@ -751,21 +589,8 @@ var loadData = function(){
     googleDriveLink();
 };
 
-/*
-var checkProjectFolder = function(){
-	if(!flashTeamsJSON.folder){
-  	console.log("creating project folder");
-	createNewFolder(document.getElementById("ft-name").innerHTML);
-	console.log("flashTeamsJSON.folder: " + flashTeamsJSON.folder);
-	//updateStatus();
-  }
-};
-*/
-
 // user must call this startTeam(true, )
 var startTeam = function(firstTime){
-    //console.log("STARTING TEAM");
-    //console.log("here1");
     if(!in_progress) {
         //flashTeamsJSON["original_json"] = JSON.parse(JSON.stringify(flashTeamsJSON));
         //flashTeamsJSON["original_status"] = JSON.parse(JSON.stringify(loadedStatus));
@@ -778,10 +603,7 @@ var startTeam = function(firstTime){
 		//checkProjectFolder();
         //addAllFolders();
         createProjectFolder();
-        //googleDriveLink();
-        //addAllTaskFolders();
         in_progress = true; // TODO: set before this?
-        //$("#projectStatusText").toggleClass('projectStatusText-inactive', true);
         $("#projectStatusText").html("The project is in progress.<br /><br />");
 
         flashTeamsJSON["paused"]=false;
@@ -793,11 +615,7 @@ var startTeam = function(firstTime){
         updateStatus(true);
 
         logActivity("var startTeam = function(firstTime) - After Update Status",'Start Team - After Update Status', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
-        //console.log("here2");
     }
-
-    //Next line is commented out after disabling the ticker
-    //setCursorMoving();
 
     // page was loaded after team started
     // OR
@@ -810,58 +628,21 @@ var startTeam = function(firstTime){
     if(page_loaded_after_start || page_loaded_before_start_and_now_started){
         if(page_loaded_before_start_and_now_started)
             user_loaded_before_team_start = false;
-        //updateAllPopoversToReadOnly();
-
-
-        //Next line is commented out after disabling the ticker
-        /*project_status_handler = setProjectStatusMoving();
-        trackLiveAndRemainingTasks();
-        trackUpcomingEvent();*/
     }
-
-
-    //Next line is commented out after disabling the ticker
-    //load_statusBar(status_bar_timeline_interval);
 };
 
-// var googleDriveLink = function(){
-//     var gFolderLink = document.getElementById("gFolder");
-//     gFolderLink.onclick=function(){
-//         //console.log("is clicked");
-//         window.open(flashTeamsJSON.folder[1]);
-//     }
-// };
-
 var drawEvents = function(editable){
-    //console.log('drawEvents is being called');
     for(var i=0;i<flashTeamsJSON.events.length;i++){
         var ev = flashTeamsJSON.events[i];
-        //console.log("DRAWING EVENT " + i + ", with editable: " + editable);
         drawEvent(ev);
-        //drawPopover(ev, editable, false);
     }
-    //checkProjectFolder();
 };
 
 var drawStartedEvents = function(){
-    //console.log('drawStartedEvents is being called');
     for(var i=0;i<flashTeamsJSON.events.length;i++){
         var ev = flashTeamsJSON.events[i];
         if(ev.status == "started" || ev.status == "delayed" ){
             drawEvent(ev);
-        }
-        //drawPopover(ev, editable, false);
-    }
-};
-
-
-// not being called right now
-var drawStartedEvTimers = function(){
-    //console.log('drawStartedEvents is being called');
-    for(var i=0;i<flashTeamsJSON.events.length;i++){
-        var ev = flashTeamsJSON.events[i];
-        if(ev.status == "started" || ev.status == "delayed" ){
-            drawTimer(ev);
         }
     }
 };
@@ -1051,129 +832,6 @@ var computeTotalOffset = function(allRanges){
 
     return totalOffset;
 };
-
-//Takes the JSON and time and updates the cursor position
-var positionCursor = function(team, latest_time){
-    //Team hasn't started, initialize cursor to 0
-    if(!team["startTime"]){
-        cursor.attr("x1", 0);
-        cursor.attr("x2", 0);
-        curr_x_standard = 0;
-        return;
-    }
-
-    cursor.transition().duration(0);
-    clearInterval(cursor_interval_id);
-
-    var currTime = latest_time;
-    var startTime = team["startTime"];
-    var diff = currTime - startTime;
-
-    var cursor_details = getXCoordForTime(diff);
-    //console.log("DIFF: " + diff);
-    //console.log("CURSOR_DETAILS: " + cursor_details);
-    var x = parseFloat(cursor_details["finalX"]);
-    //console.log("POSITIONING CURSOR AT: " + x);
-    cursor.attr("x1", x);
-    cursor.attr("x2", x);
-    curr_x_standard = x;
-
-    return cursor_details;
-};
-
-var startCursor = function(cursor_details){
-    /*
-    var x = cursor_details["finalX"];
-    var numIntervals = cursor_details["numInt"] + 1;
-    var target_x = 50*numIntervals;
-    var dist = target_x - x;
-    var t = (dist/50)*timeline_interval;
-    syncCursor(t, target_x);
-    */
-    setCursorMoving();
-};
-
-/*var syncCursor = function(length_of_time, target_x){
-    curr_x_standard = target_x;
-
-    cursor.transition()
-        .duration(length_of_time)
-        .ease("linear")
-        .attr("x1", curr_x_standard)
-        .attr("x2", curr_x_standard)
-        .each("end", function(){
-            //console.log("completed sync");
-            //console.log("sync cursor done. moving cursor normally now..");
-            setCursorMoving();
-        });
-};*/
-
-var setCursorMoving = function(){
-    cursor.transition().duration(0);
-    clearInterval(cursor_interval_id);
-
-    moveCursor(timeline_interval);
-    cursor_interval_id = setInterval(function() {
-        moveCursor(timeline_interval);
-    }, timeline_interval);
-};
-
-var moveCursor = function(length_of_time){
-    var curr_x = parseFloat(cursor.attr("x1"));
-    //console.log("STARTING TO MOVE CURSOR. STARTING X IS: " + curr_x);
-    curr_x_standard = curr_x + parseFloat(50);
-    //console.log("MOVING IT TO NEW X: " + curr_x_standard);
-
-    cursor.transition()
-        .duration(length_of_time)
-        .ease("linear")
-        .attr("x1", curr_x_standard)
-        .attr("x2", curr_x_standard);
-};
-
-var stopCursor = function() {
-    //console.log("STOPPED CURSOR");
-    cursor.transition().duration(0);
-    clearInterval(cursor_interval_id);
-};
-
-var computeLiveAndRemainingTasks = function(){
-    //console.log("computing live and remaining tasks: " + task_groups.length);
-    var curr_x = cursor.attr("x1");
-    var curr_new_x = parseFloat(curr_x) + increment;
-
-    var remaining_tasks = [];
-    var live_tasks = [];
-    for (var i=0;i<task_groups.length;i++){
-        var data = task_groups[i];
-        var groupNum = data.groupNum;
-
-        var ev = flashTeamsJSON["events"][getEventJSONIndex(groupNum)];
-        var start_x = ev.x;
-        var width = getWidth(ev);
-        var end_x = parseFloat(start_x) + parseFloat(width);
-
-
-        if(curr_new_x >= start_x && curr_new_x <= end_x && drawn_blue_tasks.indexOf(groupNum) == -1){
-
-		         //console.log("previous task does not appear to be delayed so adding task to live_task");
-                   live_tasks.push(groupNum);
-
-
-        } else if(curr_new_x < start_x){
-            remaining_tasks.push(groupNum);
-        }
-    }
-
-/*    var tasks_tmp = MoveLiveToRemaining(live_tasks,remaining_tasks);
-    live_tasks = tasks_tmp["live"];
-    remaining_tasks = tasks_tmp["remaining"];
-    updateStatus(true);
-  */
-    //console.log("returning from computing live and remaining tasks");
-    return {"live":live_tasks, "remaining":remaining_tasks};
-};
-
 
 var prevTasksDelayed = function(curr_x){
      var prevTasks = computeTasksBeforeCurrent(curr_x);
@@ -1464,80 +1122,6 @@ var moveRemainingTasksLeft = function(amount){
     moveTasksLeft(to_move, amount);
 }
 
-/*
-TODO:
-update popover when automatically shift the tasks left or right
-shorten width when finish early (?)
-offset of half of drag bar width when drawing red and blue boxes
-*/
-// not being called for user's side
-// trying to fix issue of user's page not extending delayed box (and moving remaining tasks to the right)
-// var trackLiveAndRemainingTasks = function() {
-//     tracking_tasks_interval_id = setInterval(function(){
-//         var tasks = computeLiveAndRemainingTasks();
-//         var new_live_tasks = tasks["live"];
-//         var new_remaining_tasks = tasks["remaining"];
-
-//         // extend already delayed boxes
-//         extendDelayedBoxes();
-
-//         var at_least_one_task_started = false;
-//         var at_least_one_task_delayed = false;
-
-//         // detect any live task is now delayed or completed early
-//         for (var i=0;i<live_tasks.length;i++){
-//             var groupNum = parseInt(live_tasks[i]);
-//             var task_g = getTaskGFromGroupNum (groupNum);
-//             var ev = flashTeamsJSON["events"][getEventJSONIndex(groupNum)];
-//             var completed = ev.completed_x;
-//             var task_rect_curr_width = parseFloat(getWidth(ev));
-
-//             // delayed
-//             if (new_live_tasks.indexOf(groupNum) == -1 && !completed) { // groupNum is no longer live
-//                 console.log("PREVIOUSLY LIVE TASK NOW DELAYED!");
-//                 drawRedBox(ev, task_g, false);
-
-//                 // add to delayed_tasks list
-//                 delayed_tasks.push(groupNum);
-
-//                 // updateStatus is required to send the notification email when a task is delayed
-//                 delayed_tasks_time[groupNum]=(new Date).getTime();
-
-//                 at_least_one_task_delayed = true;
-//             }
-//         }
-
-
-
-
-
-//         var tasks_tmp = MoveLiveToRemaining(new_live_tasks,new_remaining_tasks);
-//         new_live_tasks = tasks_tmp["live"];
-//         new_remaining_tasks = tasks_tmp["remaining"];
-
-//         for (var j=0;j<remaining_tasks.length;j++){
-//             var groupNum = parseInt(remaining_tasks[j]);
-//             if (new_live_tasks.indexOf(groupNum) != -1) { // groupNum is now live
-//                 at_least_one_task_started = true;
-//             }
-//         }
-
-//         live_tasks = new_live_tasks;
-//         remaining_tasks = new_remaining_tasks;
-
-
-
-//         if(at_least_one_task_delayed || at_least_one_task_started){
-//             //updateStatus(true);
-//             updateStatus();
-//             if(at_least_one_task_delayed)
-//                 at_least_one_task_delayed = false;
-//             if(at_least_one_task_started)
-//                 at_least_one_task_started = false;
-//         }
-//     }, fire_interval);
-// };
-
 //moves live task to remaining task if prev task is delayed
 function MoveLiveToRemaining(new_live_tasks,new_remaining_tasks){
     var tmp_live_tasks = [];
@@ -1545,26 +1129,18 @@ function MoveLiveToRemaining(new_live_tasks,new_remaining_tasks){
         tmp_live_tasks.push(new_live_tasks[i]);
     }
 
-
     for (var j=0;j<tmp_live_tasks.length;j++){
-       // console.log(tmp_live_tasks.length);
         var groupNum = parseInt(tmp_live_tasks[j]);
         var ev = flashTeamsJSON["events"][getEventJSONIndex(groupNum)];
         var start_x = ev.x;
-
-
         if(prevTasksDelayed(start_x)){
                   new_remaining_tasks.push(groupNum);
-
                  //remove task from live array
                  new_live_tasks.splice(new_live_tasks.indexOf(tmp_live_tasks[j]), 1);
 
         }
     }
-
-
     return {"live":new_live_tasks, "remaining":new_remaining_tasks};
-
 }
 
 
@@ -1644,133 +1220,90 @@ function getEventIndexFromId(event_id) {
 
 
 var trackUpcomingEvent = function(){
+    if (current == undefined){
+        return;
+    }
+    
+    var overallTime;
 
-     if (current == undefined){
+    currentUserEvents = currentUserEvents.sort(function(a,b){return parseInt(a.startTime) - parseInt(b.startTime)});
+
+    if (currentUserEvents.length == 0){
         return;
     }
 
-    //setInterval(function(){
+    var ev = flashTeamsJSON["events"][getEventJSONIndex(currentUserEvents[0].id)];
+    upcomingEvent = ev.id;
+    var task_g = getTaskGFromGroupNum(upcomingEvent);
 
-        var overallTime;
-
-        // if (currentUserEvents.length == 0 ){
-        //     overallTime = "You have not been assigned to any tasks yet.";
-        //     statusText.text(overallTime);
-        //     statusText.style("color", "black");
-        //     return;
-        // }
-
-        currentUserEvents = currentUserEvents.sort(function(a,b){return parseInt(a.startTime) - parseInt(b.startTime)});
-
+    while (ev.status == "completed"){
+        toDelete = upcomingEvent;
+        currentUserEvents.splice(0,1);
         if (currentUserEvents.length == 0){
+            upcomingEvent = undefined;
+
+            $("#project-status-text").html("You've completed all your tasks!");
+            $("#project-status-text").css("margin-bottom", "10px");
+            $("#project-status-text").css("color", "#3fb53f");
+
+            $("#project-status-btn").css("display", "none");
+            $("#project-status-btn2").css("display", "none");
+            $("#project-status-alert").css("display", "none");
+            $("#project-status-alert-btn").css("display", "none");
+            $("#project-status-alert-btn2").css("display", "none");
             return;
         }
+        upcomingEvent = currentUserEvents[0].id;
+        task_g = getTaskGFromGroupNum(upcomingEvent);
+        ev = flashTeamsJSON["events"][getEventJSONIndex(upcomingEvent)];
+    }
 
-        var ev = flashTeamsJSON["events"][getEventJSONIndex(currentUserEvents[0].id)];
-        upcomingEvent = ev.id;
-        var task_g = getTaskGFromGroupNum(upcomingEvent);
-
-        while (ev.status == "completed"){
-            toDelete = upcomingEvent;
-            currentUserEvents.splice(0,1);
-            if (currentUserEvents.length == 0){
-                upcomingEvent = undefined;
-
-                //overallTime = "You've completed all your tasks!";
-
-                //updateSidebarText("You've completed all your tasks!", "#3fb53f");
-
-                $("#project-status-text").html("You've completed all your tasks!");
-                $("#project-status-text").css("margin-bottom", "10px");
-                $("#project-status-text").css("color", "#3fb53f");
-
-                $("#project-status-btn").css("display", "none");
-                $("#project-status-btn2").css("display", "none");
-                $("#project-status-alert").css("display", "none");
-                $("#project-status-alert-btn").css("display", "none");
-                $("#project-status-alert-btn2").css("display", "none");
-                //statusText.style("color", "#3fb53f");
-                //statusText.text("You've completed all your tasks!");
-                return;
-            }
-            upcomingEvent = currentUserEvents[0].id;
-            task_g = getTaskGFromGroupNum(upcomingEvent);
-            ev = flashTeamsJSON["events"][getEventJSONIndex(upcomingEvent)];
-        }
-
-
-        if( ev.status == "not_started" ){
-            if(checkEventsBeforeCompletedNoAlert(upcomingEvent) && in_progress == true){
-                overallTime = "You can now start <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a> task.";
-
-                updateSidebarText(overallTime, "black");
-
-                updateStatusAlertText(overallTime, 'alert-class');
-
-                updateSidebarButton(ev.id, 'eventMousedown', 'Start Task', 'btn-warning');
-
-                updateAlertButton(ev.id, 'eventMousedown', 'Start Task', 'btn-warning');
-            }
-            else{
-                overallTime = "Your next task is <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a>.";
-
-                updateSidebarText(overallTime, "black");
-
-                updateStatusAlertText(overallTime, 'alert-hide');
-
-                updateSidebarButton(ev.id, 'eventMousedown', 'View Task', 'btn-primary');
-
-                updateAlertButton(ev.id, 'eventMousedown', 'View Task', 'btn-primary');
-            }
-        }
-
-        if( ev.status == "paused"){
-            overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is paused.";
-
-            updateSidebarText(overallTime, "#006699");
-
-            updateStatusAlertText(overallTime, 'alert-info');
-
-            updateSidebarButton(ev.id, 'resumeTask', 'Resume Task', 'btn-primary');
-
-            updateAlertButton(ev.id, 'resumeTask', 'Resume Task', 'btn-primary');
-
-        }
-
-        if( ev.status == "delayed"){
-            overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is delayed.";
-
-            updateSidebarText(overallTime, "#f52020");
-
-            updateStatusAlertText(overallTime, 'alert-danger');
-
-            updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
-
-            updateSidebarButton(ev.id, 'pauseTask', 'Take a Break', 'btn-info', 'project-status-btn2');
-
-            updateAlertButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
-            updateAlertButton(ev.id, 'pauseTask', 'Take a Break', 'btn-info', 'project-status-alert-btn2');
-        }
-
-        else if ( ev.status == "started"){
-            overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is in progress.";
-
-            updateSidebarText(overallTime, "#40b8e4");
-
+    if( ev.status == "not_started" ){
+        if(checkEventsBeforeCompletedNoAlert(upcomingEvent) && in_progress == true){
+            overallTime = "You can now start <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a> task.";
+            updateSidebarText(overallTime, "black");
+            updateStatusAlertText(overallTime, 'alert-class');
+            updateSidebarButton(ev.id, 'eventMousedown', 'Start Task', 'btn-warning');
+            updateAlertButton(ev.id, 'eventMousedown', 'Start Task', 'btn-warning');
+        } else {
+            overallTime = "Your next task is <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a>.";
+            updateSidebarText(overallTime, "black");
             updateStatusAlertText(overallTime, 'alert-hide');
-
-            updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
-
-            updateSidebarButton(ev.id, 'pauseTask', 'Pause Task', 'btn-info', 'project-status-btn2');
+            updateSidebarButton(ev.id, 'eventMousedown', 'View Task', 'btn-primary');
+            updateAlertButton(ev.id, 'eventMousedown', 'View Task', 'btn-primary');
         }
+    }
 
-        if(in_progress == true &&  (flashTeamsJSON["paused"] == true) ){
-            overallTime = "The team is being edited right now. " + overallTime;
-            updateSidebarText(overallTime);
-        }
+    if( ev.status == "paused"){
+        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is paused.";
+        updateSidebarText(overallTime, "#006699");
+        updateStatusAlertText(overallTime, 'alert-info');
+        updateSidebarButton(ev.id, 'resumeTask', 'Resume Task', 'btn-primary');
+        updateAlertButton(ev.id, 'resumeTask', 'Resume Task', 'btn-primary');
+    }
 
+    if( ev.status == "delayed"){
+        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is delayed.";
+        updateSidebarText(overallTime, "#f52020");
+        updateStatusAlertText(overallTime, 'alert-danger');
+        updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
+        updateSidebarButton(ev.id, 'pauseTask', 'Take a Break', 'btn-info', 'project-status-btn2');
+        updateAlertButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
+        updateAlertButton(ev.id, 'pauseTask', 'Take a Break', 'btn-info', 'project-status-alert-btn2');
+    }
 
-    //}, fire_interval);
+    else if ( ev.status == "started"){
+        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is in progress.";
+        updateSidebarText(overallTime, "#40b8e4");
+        updateStatusAlertText(overallTime, 'alert-hide');
+        updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'btn-success');
+        updateSidebarButton(ev.id, 'pauseTask', 'Pause Task', 'btn-info', 'project-status-btn2');
+    }
+
+    if(in_progress == true &&  (flashTeamsJSON["paused"] == true) ){
+        overallTime = "The team is being edited right now. " + overallTime;
+        updateSidebarText(overallTime);
+    }
 }
 
 // updates the project status text in the sidebar

--- a/app/assets/javascripts/authoring/request_updates.js
+++ b/app/assets/javascripts/authoring/request_updates.js
@@ -34,7 +34,6 @@ $.fn.requestUpdates = function(firstTime) {
         if(flashTeamEndedorStarted() || flashTeamUpdated()) {
             renderEverything(loadedStatus, firstTime);
         } else {
-            //console.log('requestUpdates calling drawStartedEvents');
             drawStartedEvents();
         }
   });
@@ -46,7 +45,6 @@ $.fn.subscribeToFlashTeamUpdate = function() {
     PrivatePub.subscribe(url, function(data, channel) {
         if (data) {
           renderEverything(data, false);
-          //console.log('subscribeToFlashTeamUpdate calling drawStartedEvents');
           drawStartedEvents();
         }
     });
@@ -56,7 +54,7 @@ $.fn.subscribeToFlashTeamInfo = function() {
     url = "/flash_team/" + $(this).val() + "/info"
     PrivatePub.subscribe(url, function(data, channel) {
         if (data) {
-            saveFlashTeam(data)
+            saveFlashTeam(data);
         }
     });
 }

--- a/app/assets/javascripts/authoring/timeline.js
+++ b/app/assets/javascripts/authoring/timeline.js
@@ -44,7 +44,6 @@ $("#timeline-container").css({
   backgroundColor: BKG_COLOR,
 }).append(timelineDiv);
 
-
 var d3TimelineElem = d3.select("#timeline-container .timeline");
 
 var header_svg = d3TimelineElem.append("svg")
@@ -530,5 +529,4 @@ function redrawTimeline() {
   //    $('.chart').append(this);
   //});
 }
-
 redrawTimeline();


### PR DESCRIPTION
@dretelny 

This PR performs cleanup on the front-end JS code for Foundry in the following aspects.

Removes:
1. Polling for flash team updates every 50 seconds (a remnant from the pre-PubSub days)
2. Redundant comments
3. Old code, for example, code related to the moving cursor (from back in the day)

See rationale for no. 1 at https://docs.google.com/document/d/18BUztn4jd_5GFyIL5V1O6W2ppVkYBvL6UZ5f00dw83o/edit?usp=sharing.

Testing:
Change no. 1 was tested by creating a new flash team with 80 events (the exact number as the True Story 2 team that lagged) and 5 clients. It was observed that the new team was very responsive to the mouse in general between changes to events (like start, end etc), and also fully functional.

It was slow (as expected) when a Faye update was received and it proceeded to re-render the entire timeline. This will be targeted and partially resolved by Suggestion 2 in the Google Doc above.

It was also slow (as before) when the page was first loaded and when the page was made visible after a while of being invisible. During these instances, the entire flash team is re-requested and re-rendered, which makes sense since a lot could have changed. Perhaps there is a way to make this faster as well, but it's definitely not the higher order bit here and I have not yet spent enough time thinking about how we might go about it.