### PR TITLE
Disable editing in review mode

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -325,6 +325,7 @@ function renderFlashTeamsJSON(data, firstTime) {
             $("#tourBtn").css('display','none');
             $("#flashTeamStartBtn").css('display','none');
             if(inReviewMode()){
+                in_progress = true; // to disable editing the events
                 $("#mergePullRequestBtn").css('display', '');
             } else {
                 $("#submitPullRequestBtn").css('display', '');

--- a/app/assets/javascripts/authoring/pauseTeam.js
+++ b/app/assets/javascripts/authoring/pauseTeam.js
@@ -1,6 +1,7 @@
 $("#flashTeamBranchBtn").click(function(){
     console.log("SAVING ancestor_json:");
     console.log(flashTeamsJSON);
+    var flash_team_id = $("#flash_team_id").val();
     $.ajax({
         url: '/pull_requests',
         type: 'post',
@@ -9,7 +10,6 @@ $("#flashTeamBranchBtn").click(function(){
             console.log("just created new pull request:");
             console.log(data);
             var pr_id = data.id;
-            var flash_team_id = $("#flash_team_id").val();
             $.ajax({
                 url: '/flash_teams/' + flash_team_id + '/branch',
                 type: 'post', // because not idempotent


### PR DESCRIPTION
@junwonpk 

This PR disables editing an event when in review mode (of a pull request). This prevents a reviewer from modifying the timeline inadvertently.