### PR TITLE
Fix salient issues with worker view

### DIFF
--- a/app/assets/javascripts/authoring/awareness.js
+++ b/app/assets/javascripts/authoring/awareness.js
@@ -1118,13 +1118,13 @@ var trackUpcomingEvent = function(){
 
     if( ev.status == "not_started" ){
         if(checkEventsBeforeCompletedNoAlert(upcomingEvent) && in_progress == true){
-            overallTime = "You can now start <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a> task.";
+            overallTime = "You can now start <a class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a> task.";
             updateSidebarText(overallTime, "black");
             updateStatusAlertText(overallTime, 'alert-class');
             updateSidebarButton(ev.id, 'eventMousedown', 'Start Task', 'greenlink');
             updateAlertButton(ev.id, 'eventMousedown', 'Start Task', 'greenlink');
         } else {
-            overallTime = "Your next task is <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a>.";
+            overallTime = "Your next task is <a class='task-name-status' onclick='eventMousedown(" + ev.id +")'>"+ ev.title +"</a>.";
             updateSidebarText(overallTime, "black");
             updateStatusAlertText(overallTime, 'alert-hide');
             updateSidebarButton(ev.id, 'eventMousedown', 'View Task', 'bluelink');
@@ -1133,7 +1133,7 @@ var trackUpcomingEvent = function(){
     }
 
     if( ev.status == "paused"){
-        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is paused.";
+        overallTime = "Your task <a class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is paused.";
         updateSidebarText(overallTime, "#006699");
         updateStatusAlertText(overallTime, 'alert-info');
         updateSidebarButton(ev.id, 'resumeTask', 'Resume', 'bluelink');
@@ -1141,7 +1141,7 @@ var trackUpcomingEvent = function(){
     }
 
     if( ev.status == "delayed"){
-        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is delayed.";
+        overallTime = "Your task <a class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is delayed.";
         updateSidebarText(overallTime, "#f52020");
         updateStatusAlertText(overallTime, 'alert-danger');
         updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'greenlink');
@@ -1151,7 +1151,7 @@ var trackUpcomingEvent = function(){
     }
 
     else if ( ev.status == "started"){
-        overallTime = "Your task <a href='#' class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is in progress.";
+        overallTime = "Your task <a class='task-name-status' onclick='eventMousedown(" + ev.id +")'>("+ ev.title +")</a> is in progress.";
         updateSidebarText(overallTime, "#40b8e4");
         updateStatusAlertText(overallTime, 'alert-hide');
         updateSidebarButton(ev.id, 'confirmCompleteTask', 'Complete Task', 'greenlink');

--- a/app/assets/javascripts/authoring/interactions.js
+++ b/app/assets/javascripts/authoring/interactions.js
@@ -26,9 +26,8 @@ function eventMousedown(task2idNum) {
        var modal_body = '<p id="task-text"></p>' +
        '<p><span id="task-edit-link"></span></p>';
 
-       var modal_footer =  '<button href=' + eventObj['gdrive'][1] +' class="bluelink" id="gdrive-footer-btn" target="_blank" style="float: left" onclick="logTaskOverviewGDriveBtnClick(' + task_id  + ')">Deliverables</button>' + 
+       var modal_footer =  '<button class="bluelink" id="gdrive-footer-btn" style="float: left" onclick="gDriveBtnClick(' + task_id  + ',\'' + eventObj['gdrive'][1] + '\')">Deliverables</button>' + 
        '<button class="greenlink" id="hire-task" style="float :left " onclick="hireForm('+task2idNum+')">Hire</button>' +
-       //'<button class="btn " id="duplicate-task" style="float :left " onclick="duplicateEvent('+task2idNum+', true)">Duplicate</button>' +
        createOptionsButton(task2idNum) + 
        '<button class="greenlink" id="start-end-task" style="float :right " onclick="confirm_show_docs('+task2idNum+')">Start</button>'+
        '<button class="bluelink" id="pause-resume-task" style="float :right " onclick="pauseTask('+task2idNum+')">Pause</button>'+

--- a/app/assets/javascripts/authoring/pauseTeam.js
+++ b/app/assets/javascripts/authoring/pauseTeam.js
@@ -176,25 +176,6 @@ $("#workerEditTeamBtn").click(function(){
     updateRequestChangeModal('');
 });
 
-$("#request-change-task-not-ready").click(function(){
-    logActivity("$('#request-change-task-not-ready').click(function()","Clicked 'Task is Not Ready to Start' link in sidebar", new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
-
-    updateRequestChangeModal('taskNotReady');
-});
-
-$("#request-change-edit-task").click(function(){
-    logActivity("$('#request-change-edit-task').click(function()","Clicked 'I want to edit the task' link in sidebar", new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
-
-    updateRequestChangeModal('taskEdit');
-});
-
-$("#request-change-more-time").click(function(){
-    logActivity("$('#request-change-more-time').click(function()","Clicked 'I need more time' link in sidebar", new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON);
-
-    updateRequestChangeModal('needMoreTime');
-});
-
-
 $("#requestEditSubmitBtn").click(function(){
 
     var selected = $('#request-edit-dropdown').val();

--- a/app/assets/javascripts/authoring/task_modal.js
+++ b/app/assets/javascripts/authoring/task_modal.js
@@ -142,8 +142,9 @@ function logShortTaskOverviewGDriveBtnClick(groupNum){
         logActivity("logShortTaskOverviewGDriveBtnClick(groupNum)",'Clicked on gDrive Button on Short Task Overview Modal', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
 }
 
-function logTaskOverviewGDriveBtnClick(groupNum){
-        logActivity("logTaskOverviewGDriveBtnClick(groupNum)",'Clicked on gDrive Button on Task Overview Modal', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
+function gDriveBtnClick(groupNum, gdrivelink){
+    window.open(gdrivelink, '_blank');
+    logActivity("logTaskOverviewGDriveBtnClick(groupNum)",'Clicked on gDrive Button on Task Overview Modal', new Date().getTime(), current_user, chat_name, team_id, flashTeamsJSON["events"][getEventJSONIndex(groupNum)]);
 }
 
 

--- a/app/views/flash_teams/_header.html.erb
+++ b/app/views/flash_teams/_header.html.erb
@@ -31,7 +31,6 @@
      
      <% else %> <!-- else only show the start foundry tour button --> 
 	     <div class="span2 ft-buttons" id="ft-buttons-right" style="width:auto;position:absolute;right:6px;top:6px;">
-	       <input type="button" class="greenlink" id="vcBtn" value="Join Video Call" style="display: ''" onclick="createVideoConf('<%=@flash_team.name + "_" + @flash_team.id.to_s%>');"/> 
 	       <input type="button" class="link" id="expertTourBtn" value="Start Foundry Worker Tour"/>
 	     
 

--- a/app/views/flash_teams/_header.html.erb
+++ b/app/views/flash_teams/_header.html.erb
@@ -34,18 +34,16 @@
 	       <input type="button" class="link" id="expertTourBtn" value="Start Foundry Worker Tour"/>
 	     
 
-	       <% puts "MEMBER TYPE IS:"
-              puts @member_type
-              if @member_type == 'pc' || @member_type == 'client' || @member_type == 'worker' %>
-				<% if ENV['PULL_REQUESTS'] == 'enabled' %>
+	       <%  if @member_type == 'pc' || @member_type == 'client' || @member_type == 'worker' %>
+				       <% if ENV['PULL_REQUESTS'] == 'enabled' %>
                    <input type="button" class="bluelink" id="flashTeamBranchBtn" value="Edit" target="_blank" style="display: none"/>
                    <input type="button" class="bluelink" id="submitPullRequestBtn" value="Submit Pull Request" style="display: none"/>
                    <input type="button" class="bluelink" id="mergePullRequestBtn" value="Approve and Merge" style="display: none"/>
                <% else %>
                    <input type="button" class="bluelink" id="flashTeamPauseBtn" value="Edit" style="display: none"/>
                <% end %>
-				<input type="button" class="btn btn-primary" id="flashTeamResumeBtn" value="Save" style="display: none"/>
-   		<% end %>
+				      <input type="button" class="btn btn-primary" id="flashTeamResumeBtn" value="Save" style="display: none"/>
+   		     <% end %>
 
 
 	     </div> 

--- a/app/views/flash_teams/_header.html.erb
+++ b/app/views/flash_teams/_header.html.erb
@@ -31,12 +31,13 @@
      
      <% else %> <!-- else only show the start foundry tour button --> 
 	     <div class="span2 ft-buttons" id="ft-buttons-right" style="width:auto;position:absolute;right:6px;top:6px;">
-	       <input type="button" class="btn btn-default" id="vcBtn" value="Join Video Call" style="display: ''" onclick="createVideoConf('<%=@flash_team.name + "_" + @flash_team.id.to_s%>');"/> 
+	       <input type="button" class="greenlink" id="vcBtn" value="Join Video Call" style="display: ''" onclick="createVideoConf('<%=@flash_team.name + "_" + @flash_team.id.to_s%>');"/> 
 	       <input type="button" class="link" id="expertTourBtn" value="Start Foundry Worker Tour"/>
-	       <input type="button" class="btn btn-info" id="workerEditTeamBtn" value="Request Change"  style="display: none"/>
 	     
-	       <% if @member_type == 'pc' || @member_type == 'client' %>
-		   		<input type="button" class="btn btn-info" id="workerEditTeamBtn" value="Request Change"  style="display: none"/>
+
+	       <% puts "MEMBER TYPE IS:"
+              puts @member_type
+              if @member_type == 'pc' || @member_type == 'client' || @member_type == 'worker' %>
 				<% if ENV['PULL_REQUESTS'] == 'enabled' %>
                    <input type="button" class="bluelink" id="flashTeamBranchBtn" value="Edit" target="_blank" style="display: none"/>
                    <input type="button" class="bluelink" id="submitPullRequestBtn" value="Submit Pull Request" style="display: none"/>

--- a/app/views/flash_teams/_left_sidebar.html.erb
+++ b/app/views/flash_teams/_left_sidebar.html.erb
@@ -26,22 +26,7 @@
       <div id="project-overview-container" class="sidebar-item" onclick="logSidebarClick('project-overview-container')" style="overflow-y:scroll;">
         <!-- Render project overview container --> 
         <%= render :partial => "project_overview" %> 
-      </div>
-    
-      <% unless author_runtime %>
-        
-        <!--Add a file picker for the user to start the upload process -->
-        <!--
-        <input type="file" id="filePicker" />
-        <input type="button" id="authorizeButton" style="display: none" value="Authorize" />
-        -->	
-        <div id="search-events-container" class="sidebar-item" onclick="logSidebarClick('search-events-container')">
-          <!-- render partial with event library --> 
-          <%= render :partial => "event_library" %>
-        </div>
-    
-      <% end %> <!-- end if in author runtime conditional --> 
-          
+      </div>          
     <% end %> <!-- end author view conditional -->
 
     <% if in_expert_view %>

--- a/app/views/flash_teams/_project_status.html.erb
+++ b/app/views/flash_teams/_project_status.html.erb
@@ -13,35 +13,13 @@
 
   <% elsif @author_runtime == true %>
       <p class="projectStatusText" id="projectStatusText"></p>
-      <!-- <p class="projectStatusText" id="projectStatusText">The project is in progress.<br /><br /></p> -->
-
   <% end %>
 
     <div id = 'project-status-text-div' style="margin-bottom: 25px;">
 
           <p id = 'project-status-text'></p>
 
-          <button class="btn project-status-btn btn-block btn-default" id="project-status-btn" style="display: none">Project Status Button</button>
-          <button class="btn project-status-btn btn-block btn-default" id="project-status-btn2" style="display: none">Project Status Button</button>
+          <button class="project-status-btn" id="project-status-btn" style="display: none">Project Status Button</button>
+          <button class="project-status-btn" id="project-status-btn2" style="display: none">Project Status Button</button>
     </div>
-
-    <% if @in_expert_view && @author_runtime != false %>
-       <div id = 'request-change-div' style="margin-bottom: 25px;">
-            <p class ='request-change-link'><a id="request-change-task-not-ready">A task isn't ready to start</a></p> 
-            <p class ='request-change-link'><a id="request-change-edit-task">I want to edit a task</a></p>
-            <p class ='request-change-link'><a id="request-change-more-time">I need more time</a></p>
-      </div>
-    <% end %>
-
-
-    
-  
-  <!--<p style="font-weight: 400;margin-top: 11px;">Progress Status:</p>
-  <div class="progress progress-bar" style="background: #ffffff !important; border:solid 1px #c3c3c3;">
-      <div class="bar" style=" width: 0%; transition:width 1s linear;
-      -moz-transition:width 1s linear; 
-      -webkit-transition:width 1s linear; 
-      -o-transition:width 1s linear;" >
-      </div>
-  </div> -->
 </div>

--- a/app/views/flash_teams/_task_acceptance_content.html.erb
+++ b/app/views/flash_teams/_task_acceptance_content.html.erb
@@ -102,7 +102,7 @@
 							</p>
 	
 							<p>
-								After you sign up, you will receive a unique link to the project, which you should use throughout the project. If you are still unfamiliar with Foundry, you can access the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the project page.  Feel free to contact us if you have any remaining questions.
+								After you sign up, you will receive a unique link to the project, which you should use throughout the project. If you are still unfamiliar with Foundry, you can access the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the project page.  Feel free to contact us if you have any remaining questions.
 							</p>  
 						
 							<p>

--- a/app/views/flash_teams/_task_acceptance_email_content.html.erb
+++ b/app/views/flash_teams/_task_acceptance_email_content.html.erb
@@ -40,7 +40,7 @@
 						</p>
 						
 						<p>
-								After you sign up, you will receive a unique link to the project, which you should use throughout the project. If you are still unfamiliar with Foundry, you can access the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the project page.  Feel free to contact us if you have any remaining questions.
+								After you sign up, you will receive a unique link to the project, which you should use throughout the project. If you are still unfamiliar with Foundry, you can access the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the project page.  Feel free to contact us if you have any remaining questions.
 							</p>  
 						
 							<p>

--- a/app/views/flash_teams/_task_acceptance_email_content_landing.html.erb
+++ b/app/views/flash_teams/_task_acceptance_email_content_landing.html.erb
@@ -42,7 +42,7 @@
 						<p><%=link_to "Click here to register for this position on Foundry", @invitationLink%></p>
 						
 						<p>
-							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us if you have any remaining questions.
+							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the page.  Feel free to contact us if you have any remaining questions.
 						</p>  
 						
 						

--- a/app/views/flash_teams/_timeline.html.erb
+++ b/app/views/flash_teams/_timeline.html.erb
@@ -5,10 +5,10 @@
     <p> 
     	<span id='project-status-alert-text'></span>
 
-    <button class="btn project-status-alert-btn btn-mini btn-default" id="project-status-alert-btn" style="float: right; margin-left: 5px; display: none">
+    <button class="project-status-alert-btn" id="project-status-alert-btn" style="float: right; margin-left: 5px; display: none">
     	Project Status Button
     </button>
-     <button class="btn project-status-alert-btn btn-mini btn-default" id="project-status-alert-btn2" style="float: right; display: none">
+     <button class="project-status-alert-btn" id="project-status-alert-btn2" style="float: right; display: none">
     	Project Status Button
     </button>
     </p>

--- a/app/views/landings/_task_acceptance_email_content_landing.html.erb
+++ b/app/views/landings/_task_acceptance_email_content_landing.html.erb
@@ -75,7 +75,7 @@
 						<p><%=link_to "Click here to register for this position on Foundry", @invitationLink%></p>
 						
 						<p>
-							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us if you have any remaining questions.
+							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the page.  Feel free to contact us if you have any remaining questions.
 						</p>  
 						
 			<p>Again, if you would not like to work on this project any more, <%=link_to "Click here to give up your spot in the hiring queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%> so that others can be offered the job.</p>

--- a/app/views/landings/_task_waiting_email_content_landing.html.erb
+++ b/app/views/landings/_task_waiting_email_content_landing.html.erb
@@ -63,7 +63,7 @@
 						
 					
 						<p>
-							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us if you have any remaining questions.
+							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the page.  Feel free to contact us if you have any remaining questions.
 						</p>  
 										
 			<p>Again, if you would not like to work on this project any more, <%=link_to "click here to give up your spot in the hiring queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%> so that others can be offered the job.</p>

--- a/app/views/user_mailer/_first_in_queue.html.erb
+++ b/app/views/user_mailer/_first_in_queue.html.erb
@@ -75,7 +75,7 @@
 						<p><%=link_to "Click here to register for this position on Foundry", @invitationLink%></p>
 						
 						<p>
-							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.  Feel free to contact us if you have any remaining questions.
+							After you sign up, you will receive a unique link to the project, which you should use throughout the project. As stated in our previous email, we will be asking you to use our platform, Foundry, to keep track of your progress and submit your work. If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Worker Tour" button on the top right of the page.  Feel free to contact us if you have any remaining questions.
 						</p>  
 						
 			<p>Again, if you would not like to work on this project any more, <%=link_to "Click here to give up your spot in the hiring queue", @removalURL, :data=>{:confirm=>"Are you sure you want to be removed from the hiring queue?"}%> so that others can be offered the job.</p>


### PR DESCRIPTION
@junwonpk 

This PR fixes some of the salient issues with the worker view, as listed in [this Google Doc](https://docs.google.com/document/d/1BE_E0GmJfawgdZhEe2N66tswTxSuRgWd6TjzJF-uLrU/edit#).

Namely, the issues are:
- Clicking on links in the following section of event popover after filling it out leads to an undefined page: “Review the following tasks and deliverables, which are important for your task”
- ‘Deliverables’ link not working on event popover after team has started
- Worker view is a little messed up in the view
- Worker is provided option to suggest change to event -- take out? Furthermore, the link this sends to Slack for review is broken
- All of the following lead to the suggest change feature, which is broken
- Task Available text outdated: If you are still unfamiliar with Foundry, view the Foundry tour by clicking the "Start Foundry Tour" button on the top left of the page.
- Hide event library for now