### PR TITLE
Slack integration fix

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -6,8 +6,7 @@ class SlackController < ApplicationController
     response = client.oauth_access(
       client_id: ENV['SLACK_APP_CLIENT_ID'],
       client_secret: ENV['SLACK_APP_CLIENT_SECRET'],
-      code: params[:code],
-      redirect_uri: "http://localhost:3000/slack/auth/"
+      code: params[:code]
     )
     flash[:slack_info] = response
     redirect_to params[:state]


### PR DESCRIPTION
@junwonpk 

On heroku, the `redirect_uri` of `http://localhost:3000/slack/auth` doesn't work. As per the Slack API, this field is optional anyway, so removing it. Will test on Heroku after this to see if it works.

@junwonpk Let me know if you know of a proper way to solve this issue.