### PR TITLE
Revamp invite flow for new workers

### DIFF
--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -56,8 +56,8 @@ class LandingsController < ApplicationController
 
     @task_members.each do |task_member|
       if task_member['role'] == @task_member
-        @invitationLink = task_member['invitation_link']
         @uniq = task_member['uniq']
+        @invitationLink = url_for :controller => 'members', :action => 'invited_by_hiring_queue', :id_team => @id_team, :uniq => @uniq, :email => @email
         break
       end
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -37,6 +37,11 @@ class UserMailer < ActionMailer::Base
   	  mail(:to => email, :subject => title+' is finished')
   end
 
+  def send_team_link_email(name, email_address, url)
+    @url = url
+    @name = name
+    mail(:to => email_address, :subject => 'Link to your foundry team')
+  end
 
   def send_confirmation_email(name, email_address, url)
   	@url = url

--- a/app/views/members/invited.html.erb
+++ b/app/views/members/invited.html.erb
@@ -11,7 +11,8 @@
 
 <div class="center">
 	<%= form_tag("/members/#{@id}/register", method: "post") do %>
-	   <table class="inputs">
+	   <%= hidden_field_tag 'uniq', @uniq %>
+       <table class="inputs">
 	   		<tr>
 	   			<td>
 	   				<%= text_field_tag :name, "", class: 'inputbox', placeholder: 'Full Name (e.g. John Smith)' %> <br />
@@ -29,12 +30,4 @@
 	        </tr>
 	   </table>
 	<% end %>
-</div>
-<div class="bottom_msg">
-  <p>
-    <br />
-    <i> * If you received this task via the instant hiring system, please use the same email address that you used to
-    <br />
-    register for the panels on Foundry (e.g., the email address where you received the task available email)</i>
-  </p>
 </div>

--- a/app/views/user_mailer/send_team_link_email.html.erb
+++ b/app/views/user_mailer/send_team_link_email.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+      
+      <p>Hi <%=@name%>,</p>
+      
+    <p>
+      Thanks for joining a team on Foundry! You can use the following link to access your team anytime:
+    </p>
+    <p>
+      <%=@url%>
+    </p>
+    <p>Sincerely, <br />
+        The Foundry Team
+    </p>
+  </body>
+</html>

--- a/app/views/user_mailer/send_team_link_email.text.erb
+++ b/app/views/user_mailer/send_team_link_email.text.erb
@@ -1,0 +1,7 @@
+Hi <%=@name%>,
+      
+Thanks for joining a team on Foundry! You can use the following link to access your team anytime:
+<%=@url%>
+    
+Sincerely, 
+The Foundry Team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ get '/flash_teams/:id/:event_id/listQueueForm' => 'flash_teams#listQueueForm'
       get :invited
       get :confirm_email
       post :register
+      get :invited_by_hiring_queue
     end
   end
 


### PR DESCRIPTION
@junwonpk cc: @mbernst 

This PR revamps the invite flow for new workers. It resolves a fatal issue regarding worker onboarding encountered during the foundry test during the last Flash meeting.

There are two main ways to invite a member:

1. Via the hiring portal (i.e. click on `Hire` on a task)
- does not require email confirmation because it is assumed the worker received the original request in their email anyway
- as soon as the worker accepts the job, the worker is automatically registered and redirected to the team page right away
- an email is sent to them with the link to the team (for future use)

2. Via the direct invite link (as obtained by clicking on a role on the left sidebar)
- this requires the worker to register and confirm their email to gain access to the team page
- like above, an email is then sent to them with the link to the team (for future use)